### PR TITLE
Fix enable_irq interpretation of primask

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -34,7 +34,7 @@ inline int disable_irq(void) {
 }
 
 inline void enable_irq(int primask) {
-    if (primask)
+    if (!primask)
         asm volatile("cpsie i\n");
 }
 


### PR DESCRIPTION
The logic for enable_irq is backwards; it should enable interrupts when primask is 0, not 1.