### PR TITLE
fix CMakeLists + explicit LED polarity settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ endfunction()
 
 ########## generate list of targets.
 # the "_fw" part is appended automatically
-set(TGT042_LIST "cantact" "canalyze" canable" "usb2can")
+set(TGT042_LIST "cantact" "canalyze" "canable" "usb2can")
 set(TGT072_LIST "candleLight")
 
 

--- a/include/config.h
+++ b/include/config.h
@@ -50,12 +50,12 @@ THE SOFTWARE.
 	#define LED1_Pin GPIO_PIN_0
 	#define LED1_Mode GPIO_MODE_OUTPUT_OD
 	#define LED1_GPIO_Port GPIOA
-	#define LED1_Active_Low
+	#define LED1_Active_High 0
 
 	#define LED2_GPIO_Port GPIOA
 	#define LED2_Pin GPIO_PIN_1
 	#define LED2_Mode GPIO_MODE_OUTPUT_OD
-	#define LED2_Active_Low
+	#define LED2_Active_High 0
 
 #elif BOARD == BOARD_cantact
 	#define USBD_PRODUCT_STRING_FS		(uint8_t*) "cantact gs_usb"
@@ -67,10 +67,12 @@ THE SOFTWARE.
 	#define LED1_GPIO_Port GPIOB
 	#define LED1_Pin GPIO_PIN_0	/* green */
 	#define LED1_Mode GPIO_MODE_OUTPUT_PP
+	#define LED1_Active_High 1
 
 	#define LED2_GPIO_Port GPIOB
 	#define LED2_Pin GPIO_PIN_1	/* red */
 	#define LED2_Mode GPIO_MODE_OUTPUT_PP
+	#define LED2_Active_High 1
 
 #elif BOARD == BOARD_canable
 	#define USBD_PRODUCT_STRING_FS			(uint8_t*) "canable gs_usb"
@@ -82,10 +84,12 @@ THE SOFTWARE.
 	#define LED1_GPIO_Port GPIOB
 	#define LED1_Pin GPIO_PIN_0	/* green */
 	#define LED1_Mode GPIO_MODE_OUTPUT_PP
+	#define LED1_Active_High 1
 
 	#define LED2_GPIO_Port GPIOB
 	#define LED2_Pin GPIO_PIN_1	/* blue */
 	#define LED2_Mode GPIO_MODE_OUTPUT_PP
+	#define LED2_Active_High 1
 
 #elif BOARD == BOARD_usb2can
 	#define USBD_PRODUCT_STRING_FS		(uint8_t*) "USB2CAN RCA gs_usb"
@@ -102,7 +106,7 @@ THE SOFTWARE.
 	#define LED2_GPIO_Port GPIOA
 	#define LED2_Pin GPIO_PIN_1	/* blue */
 	#define LED2_Mode GPIO_MODE_OUTPUT_OD
-	#define LED2_Active_Low
+	#define LED2_Active_High 0
 
 	#define LED3_GPIO_Port GPIOA
 	#define LED3_Pin GPIO_PIN_2	/* red */
@@ -112,7 +116,7 @@ THE SOFTWARE.
 	#define LED1_GPIO_Port GPIOB
 	#define LED1_Pin GPIO_PIN_3	/* green */
 	#define LED1_Mode GPIO_MODE_OUTPUT_OD
-	#define LED1_Active_Low
+	#define LED1_Active_High 0
 #elif BOARD == BOARD_canalyze
 	#define USBD_PRODUCT_STRING_FS		(uint8_t*) "CANAlyze gs_usb"
 	#define USBD_MANUFACTURER_STRING	(uint8_t*) "STMicroelectronics"
@@ -123,10 +127,12 @@ THE SOFTWARE.
 	#define LED1_GPIO_Port GPIOB
 	#define LED1_Pin GPIO_PIN_0	/* green */
 	#define LED1_Mode GPIO_MODE_OUTPUT_PP
+	#define LED1_Active_High 1
 
 	#define LED2_GPIO_Port GPIOB
 	#define LED2_Pin GPIO_PIN_1	/* red */
 	#define LED2_Mode GPIO_MODE_OUTPUT_PP
+	#define LED2_Active_High 1
 #else
 	#error please define BOARD
 #endif

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -44,10 +44,10 @@ void gpio_init()
 	HAL_GPIO_Init(CAN_S_GPIO_Port, &GPIO_InitStruct);
 #endif
 
-#ifdef LED1_Active_Low
-	HAL_GPIO_WritePin(LED1_GPIO_Port, LED1_Pin, GPIO_PIN_SET);
-#else
+#if (LED1_Active_High == 1)
 	HAL_GPIO_WritePin(LED1_GPIO_Port, LED1_Pin, GPIO_PIN_RESET);
+#else
+	HAL_GPIO_WritePin(LED1_GPIO_Port, LED1_Pin, GPIO_PIN_SET);
 #endif
 	GPIO_InitStruct.Pin = LED1_Pin;
 	GPIO_InitStruct.Mode = LED1_Mode;
@@ -55,10 +55,10 @@ void gpio_init()
 	GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
 	HAL_GPIO_Init(LED1_GPIO_Port, &GPIO_InitStruct);
 
-#ifdef LED2_Active_Low
-	HAL_GPIO_WritePin(LED2_GPIO_Port, LED2_Pin, GPIO_PIN_SET);
-#else
+#if (LED2_Active_High == 1)
 	HAL_GPIO_WritePin(LED2_GPIO_Port, LED2_Pin, GPIO_PIN_RESET);
+#else
+	HAL_GPIO_WritePin(LED2_GPIO_Port, LED2_Pin, GPIO_PIN_SET);
 #endif
 	GPIO_InitStruct.Pin = LED2_Pin;
 	GPIO_InitStruct.Mode = LED2_Mode;

--- a/src/main.c
+++ b/src/main.c
@@ -69,11 +69,7 @@ int main(void)
 
 	gpio_init();
 
-#if BOARD == BOARD_canable
-	led_init(&hLED, LED1_GPIO_Port, LED1_Pin, true, LED2_GPIO_Port, LED2_Pin, true);
-#else
-	led_init(&hLED, LED1_GPIO_Port, LED1_Pin, false, LED2_GPIO_Port, LED2_Pin, false);
-#endif
+	led_init(&hLED, LED1_GPIO_Port, LED1_Pin, LED1_Active_High, LED2_GPIO_Port, LED2_Pin, LED2_Active_High);
 	led_set_mode(&hLED, led_mode_off);
 	timer_init();
 
@@ -107,7 +103,7 @@ int main(void)
 				// Echo sent frame back to host
 				frame->timestamp_us = timer_get();
 				send_to_host_or_enqueue(frame);
-				
+
 				led_indicate_trx(&hLED, led_2);
 			} else {
 				queue_push_front(q_from_host, frame); // retry later
@@ -237,7 +233,7 @@ void send_to_host()
 
 	if(!frame)
 	  return;
-	
+
 	if (USBD_GS_CAN_SendFrame(&hUSB, frame) == USBD_OK) {
 		queue_push_back(q_frame_pool, frame);
 	} else {


### PR DESCRIPTION
I failed to test the build on the last PR merge and broke cmake due to a syntax error (missing ").

Also inverts the LED logic for the canalyze board, and sets explicitly the polarity for all board types.

@brandonros , please test your device against this