### PR TITLE
LED: modify trx status led

### DIFF
--- a/src/led.c
+++ b/src/led.c
@@ -94,7 +94,13 @@ void led_indicate_trx(led_data_t *leds, led_num_t num)
 static void led_update_normal_mode(led_state_t *led)
 {
 	uint32_t now = HAL_GetTick();
-	led_set(led, led->off_until < now);
+	if (led->off_until < now) {
+		if (led->on_until < now) {
+			led_set(led, 0);
+		} else {
+			led_set(led, 1);
+		}
+	}
 }
 
 static void led_update_sequence(led_data_t *leds)


### PR DESCRIPTION
I thought the LEDs behaved strangely, but after thinking about it it's possibly better the way it is now :

- when interface is down (ip link set can0 down), both LEDs are off
- interface is up : TX+RX are solid on
- send/receive activity make the corresponding LED blink
- the "identify" feature (`ehtool -p can0`) works as expected

This PR changes the "normal" state to both LEDs being off. Other behavior (blinking, identify) is not changed. The disadvantage of course is that there's no more indication of the interface being up/down.

@HubertD , do I understand correctly the original intent ?