### PR TITLE
Reset CAN on USB suspend. Fixes #46.

### DIFF
--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -47,6 +47,7 @@ extern USBD_ClassTypeDef USBD_GS_CAN;
 
 uint8_t USBD_GS_CAN_Init(USBD_HandleTypeDef *pdev, queue_t *q_frame_pool, queue_t *q_from_host, led_data_t *leds);
 void USBD_GS_CAN_SetChannel(USBD_HandleTypeDef *pdev, uint8_t channel, can_data_t* handle);
+void USBD_GS_CAN_SuspendCallback(USBD_HandleTypeDef  *pdev);
 bool USBD_GS_CAN_TxReady(USBD_HandleTypeDef *pdev);
 uint8_t USBD_GS_CAN_PrepareReceive(USBD_HandleTypeDef *pdev);
 bool USBD_GS_CAN_CustomDeviceRequest(USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef *req);

--- a/src/usbd_conf.c
+++ b/src/usbd_conf.c
@@ -90,6 +90,7 @@ void HAL_PCD_ResetCallback(PCD_HandleTypeDef *hpcd)
 
 void HAL_PCD_SuspendCallback(PCD_HandleTypeDef *hpcd)
 {
+	USBD_GS_CAN_SuspendCallback((USBD_HandleTypeDef*)hpcd->pData);
 	USBD_LL_Suspend((USBD_HandleTypeDef*)hpcd->pData);
 }
 

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -349,6 +349,24 @@ void USBD_GS_CAN_SetChannel(USBD_HandleTypeDef *pdev, uint8_t channel, can_data_
 	}
 }
 
+// Handle USB suspend event
+void USBD_GS_CAN_SuspendCallback(USBD_HandleTypeDef  *pdev)
+{
+	// Disable CAN and go off bus on USB suspend
+	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*) pdev->pClassData;
+
+	if(hcan != NULL)
+	{
+		for(uint32_t i=0; i<NUM_CAN_CHANNEL; i++)
+			if(hcan->channels[i] != NULL)
+				can_disable(hcan->channels[i]);
+	}
+
+	if(hcan != NULL && hcan->leds != NULL)
+		led_set_mode(hcan->leds, led_mode_off);
+}
+
+
 static led_seq_step_t led_identify_seq[] = {
 	{ .state = 0x01, .time_in_10ms = 10 },
 	{ .state = 0x02, .time_in_10ms = 10 },


### PR DESCRIPTION
This fixes issue #46, where the host system reboots or restarts the USB port while the microcontroller running this firmware continues running.

This is accomplished by disabling all CAN ports when the USB Suspend event occurs. This particular implementation is not my favorite (modifying usbd_conf.c) but I couldn't come up with a cleaner way to implement this.