### PR TITLE
Update CANable-specific LED initialization

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -77,7 +77,7 @@ THE SOFTWARE.
 #elif BOARD == BOARD_canable
 	#define USBD_PRODUCT_STRING_FS			(uint8_t*) "canable gs_usb"
 	#define USBD_MANUFACTURER_STRING		(uint8_t*) "canable.io"
-	#define DFU_INTERFACE_STRING_FS			(uint8_t*) "canble firmware upgrade interface"
+	#define DFU_INTERFACE_STRING_FS			(uint8_t*) "canable firmware upgrade interface"
 
 	// SILENT pin not connected
 
@@ -89,7 +89,7 @@ THE SOFTWARE.
 	#define LED2_GPIO_Port GPIOB
 	#define LED2_Pin GPIO_PIN_1	/* blue */
 	#define LED2_Mode GPIO_MODE_OUTPUT_PP
-	#define LED2_Active_High 1
+	#define LED2_Active_High 0
 
 #elif BOARD == BOARD_usb2can
 	#define USBD_PRODUCT_STRING_FS		(uint8_t*) "USB2CAN RCA gs_usb"

--- a/src/main.c
+++ b/src/main.c
@@ -70,6 +70,17 @@ int main(void)
 	gpio_init();
 
 	led_init(&hLED, LED1_GPIO_Port, LED1_Pin, LED1_Active_High, LED2_GPIO_Port, LED2_Pin, LED2_Active_High);
+
+#if BOARD == BOARD_canable
+    for(uint8_t i=0; i<10; i++)
+    {
+        HAL_GPIO_TogglePin(LED1_GPIO_Port, LED1_Pin);
+        HAL_Delay(50);
+        HAL_GPIO_TogglePin(LED2_GPIO_Port, LED2_Pin);
+    }
+#endif
+
+
 	led_set_mode(&hLED, led_mode_off);
 	timer_init();
 


### PR DESCRIPTION
This commit adds blinking on startup for CANable devices (could enable for all boards if desired). It also inverts the behavior of the power LED to better indicate when the device is powered on as CANable devices do not have a dedicated power LED.

This also fixes a typo in the CANable DFU USB string.