### PR TITLE
Always queue frames to the host in order

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -220,20 +220,8 @@ void SystemClock_Config(void)
 
 bool send_to_host_or_enqueue(struct gs_host_frame *frame)
 {
-	if (USBD_GS_CAN_GetProtocolVersion(&hUSB) == 2) {
-		queue_push_back(q_to_host, frame);
-		return true;
-
-	} else {
-		bool retval = false;
-		if ( USBD_GS_CAN_SendFrame(&hUSB, frame) == USBD_OK ) {
-			queue_push_back(q_frame_pool, frame);
-			retval = true;
-		} else {
-			queue_push_back(q_to_host, frame);
-		}
-		return retval;
-	}
+	queue_push_back(q_to_host, frame);
+	return true;
 }
 
 void send_to_host()


### PR DESCRIPTION
The other logic could sometimes send frames out of order. I only
observed it with test code that sends lots of frames really fast, but it
could happen with normal traffic too.

I don't see why the logic was different in the first place either. The
main loop executes pretty fast, so always putting the frame in the queue
makes all the logic simpler.