### PR TITLE
Add appropriate memory barriers for disable_irq/enable_irq

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -33,7 +33,7 @@ THE SOFTWARE.
 // delay in the effect of enabling and disabling interrupts.
 // That probably doesn't matter here, but it's hard to say what the compiler
 // will put in those 2 instructions so it's safer to leave it. The DSB isn't
-// necessary on Cortex-M0, but it's architecturally required so we'l
+// necessary on Cortex-M0, but it's architecturally required so we'll
 // include it to be safe.
 //
 // The "memory" and "cc" clobbers tell GCC to avoid moving memory loads or


### PR DESCRIPTION
I noticed these were wrong while investigating
candle-usb/candleLight_fw#58. I don't think any of these changes have
any effect right now though, due to the current compiler version and
settings.