### PR TITLE
Return .user_data section to linker scripts to fix flash saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is firmware for certain STM32F042x/STM32F072xB-based USB-CAN adapters, nota
 - USB2CAN: https://github.com/roboterclubaachen/usb2can (STM32F042x6)
 - CANAlyze: https://kkuchera.github.io/canalyze/ (STM32F042C6)
 - VulCAN Gen1: https://shop.copperforge.cc/products/ac41 (STM32F042x6)
+- Entreé: https://github.com/tuna-f1sh/entree (STM32F042x6)
 
 Of important note is that the common STM32F103 will NOT work with this firmware because its hardware cannot use both USB and CAN simultaneously.
 Beware also the smaller packages in the F042 series which map a USB and CAN_TX signal on the same pin and are therefore unusable !

--- a/ldscripts/STM32F042X6.ld
+++ b/ldscripts/STM32F042X6.ld
@@ -1,10 +1,14 @@
 __STACK_SIZE = 1024;
 __HEAP_SIZE  = 2560;
 
+__FLASH_SIZE = 32K;
+__NVM_SIZE = 1K;
+
 MEMORY
 {
-  FLASH (rx)  : ORIGIN = 0x08000000, LENGTH = 32K
+  FLASH (rx)  : ORIGIN = 0x08000000, LENGTH = __FLASH_SIZE - __NVM_SIZE
   RAM   (rwx) : ORIGIN = 0x20000000, LENGTH = 6K
+  DATA (xrw) : ORIGIN = 0x08000000 + __FLASH_SIZE - __NVM_SIZE, LENGTH = __NVM_SIZE
 }
 
 ENTRY(Reset_Handler)
@@ -68,6 +72,13 @@ SECTIONS
   } > FLASH
 
   __etext = ALIGN (4);
+
+  .user_data :
+  {
+    . = ALIGN(4);
+    *(.user_data)
+    . = ALIGN(4);
+  } > DATA
 
   .data : AT (__etext)
   {

--- a/ldscripts/STM32F072XB.ld
+++ b/ldscripts/STM32F072XB.ld
@@ -1,11 +1,16 @@
 __STACK_SIZE = 2K;
 __HEAP_SIZE  = 10K;
 
+__FLASH_SIZE = 128K;
+__NVM_SIZE = 1K;
+
 MEMORY
 {
-  FLASH (rx)  : ORIGIN = 0x08000000, LENGTH = 128K
+  FLASH (rx)  : ORIGIN = 0x08000000, LENGTH = __FLASH_SIZE - __NVM_SIZE
   RAM   (rwx) : ORIGIN = 0x20000000, LENGTH = 16K
+  DATA (xrw) : ORIGIN = 0x08000000 + __FLASH_SIZE - __NVM_SIZE, LENGTH = __NVM_SIZE
 }
+
 
 ENTRY(Reset_Handler)
 
@@ -68,6 +73,13 @@ SECTIONS
   } > FLASH
 
   __etext = ALIGN (4);
+
+  .user_data :
+  {
+    . = ALIGN(4);
+    *(.user_data)
+    . = ALIGN(4);
+  } > DATA
 
   .data : AT (__etext)
   {


### PR DESCRIPTION
Developing on my [candleLight fork](https://github.com/tuna-f1sh/candleLight_fw) to add support for USB-PD, I needed to add more settings to flash. Doing this caused me to find that the `.user_data` flash sector has been dropped during the linker script migration. 

Basically, the flash saving of user id is not properly defined at the moment and has the potential to over-write application flash.

This PR ports [this commit from 2016](https://github.com/candle-usb/candleLight_fw/commit/1453d70dc9a9d98ac254893ba5114b8e826e0e39), which reduces the application flash region by 2K and allocates a page for flash memory at the end of the flash area. 

I've also added my [new board](https://github.com/tuna-f1sh/entree) as a supported board. I've love to merge all the code from my master fork into this - is there appetite for that? It does [add quite a few things](https://github.com/candle-usb/candleLight_fw/compare/master...tuna-f1sh:master), including i2c but it's all kept board specific so shouldn't impact other hardware.