### PR TITLE
Add basic assert checks

### DIFF
--- a/include/util.h
+++ b/include/util.h
@@ -54,7 +54,7 @@ static inline bool is_irq_enabled(void)
 	return (__get_PRIMASK() & 1u) == 0u; // interrupts not prevented
 }
 
-static inline bool disable_irq(void) 
+static inline bool disable_irq(void)
 {
 	bool was_enabled = is_irq_enabled();
 	__disable_irq();
@@ -62,9 +62,31 @@ static inline bool disable_irq(void)
 	return was_enabled;
 }
 
-static inline void enable_irq() 
+static inline void enable_irq()
 {
 	__enable_irq();
     __ISB();
 }
 
+/* Lightweight assert macro to replace standard assert()
+ *
+ * Standard assert() needs fprint, __FILE__ , __LINE__ string consts etc.
+ *
+ * stm32's library has "USE_FULL_ASSERT" to enable some checks, but they have
+ * their own assert_param() macro that also passes in __FILE__, __LINE__ so
+ * I'm not sure if (and how) it'll be possible to combine both.
+ *
+ * Interesting notes on
+ * https://barrgroup.com/embedded-systems/how-to/define-assert-macro
+ *
+ */
+#define assert_basic(exp)   \
+		if (exp) {			\
+		} else 				\
+			assert_failed()
+
+/** halt / set core to debug state with BKPT.
+ *
+ * TODO : save extra info somewhere in RAM, and let WDT auto-reset ?
+ */
+void assert_failed(void);

--- a/src/main.c
+++ b/src/main.c
@@ -41,6 +41,7 @@ THE SOFTWARE.
 #include "dfu.h"
 #include "timer.h"
 #include "flash.h"
+#include "util.h"
 
 void HAL_MspInit(void);
 void SystemClock_Config(void);
@@ -89,8 +90,11 @@ int main(void)
 	q_frame_pool = queue_create(CAN_QUEUE_SIZE);
 	q_from_host  = queue_create(CAN_QUEUE_SIZE);
 	q_to_host    = queue_create(CAN_QUEUE_SIZE);
+	assert_basic(q_frame_pool && q_from_host && q_to_host);
 
 	struct gs_host_frame *msgbuf = calloc(CAN_QUEUE_SIZE, sizeof(struct gs_host_frame));
+	assert_basic(msgbuf);
+
 	for (unsigned i=0; i<CAN_QUEUE_SIZE; i++) {
 		queue_push_back(q_frame_pool, &msgbuf[i]);
 	}
@@ -112,7 +116,7 @@ int main(void)
 				// Echo sent frame back to host
 				frame->timestamp_us = timer_get();
 				send_to_host_or_enqueue(frame);
-				
+
 				led_indicate_trx(&hLED, led_2);
 			} else {
 				queue_push_front(q_from_host, frame); // retry later
@@ -231,7 +235,7 @@ void send_to_host()
 
 	if(!frame)
 	  return;
-	
+
 	if (USBD_GS_CAN_SendFrame(&hUSB, frame) == USBD_OK) {
 		queue_push_back(q_frame_pool, frame);
 	} else {

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -290,22 +290,17 @@ static const struct gs_device_bt_const USBD_GS_CAN_btconst = {
 
 uint8_t USBD_GS_CAN_Init(USBD_HandleTypeDef *pdev, queue_t *q_frame_pool, queue_t *q_from_host, led_data_t *leds)
 {
-	uint8_t ret = USBD_FAIL;
 	USBD_GS_CAN_HandleTypeDef *hcan = calloc(1, sizeof(USBD_GS_CAN_HandleTypeDef));
 
-	if(hcan != 0) {
-		hcan->q_frame_pool = q_frame_pool;
-		hcan->q_from_host = q_from_host;
-		hcan->leds = leds;
-		pdev->pClassData = hcan;
-		hcan->from_host_buf = NULL;
+	assert_basic(hcan);
 
-		ret = USBD_OK;
-	} else {
-		pdev->pClassData = 0;
-	}
+	hcan->q_frame_pool = q_frame_pool;
+	hcan->q_from_host = q_from_host;
+	hcan->leds = leds;
+	pdev->pClassData = hcan;
+	hcan->from_host_buf = NULL;
 
-	return ret;
+	return USBD_OK;
 }
 
 
@@ -313,20 +308,17 @@ uint8_t USBD_GS_CAN_Init(USBD_HandleTypeDef *pdev, queue_t *q_frame_pool, queue_
 static uint8_t USBD_GS_CAN_Start(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
 {
 	UNUSED(cfgidx);
-	uint8_t ret = USBD_FAIL;
 
-	if (pdev->pClassData) {
-	  USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*) pdev->pClassData;
-		USBD_LL_OpenEP(pdev, GSUSB_ENDPOINT_IN, USBD_EP_TYPE_BULK, CAN_DATA_MAX_PACKET_SIZE);
-		USBD_LL_OpenEP(pdev, GSUSB_ENDPOINT_OUT, USBD_EP_TYPE_BULK, CAN_DATA_MAX_PACKET_SIZE);
-                hcan->from_host_buf = queue_pop_front(hcan->q_frame_pool);
-		USBD_GS_CAN_PrepareReceive(pdev);
-		ret = USBD_OK;
-	} else {
-		ret = USBD_FAIL;
-	}
+	assert_basic(pdev->pClassData);
 
-	return ret;
+	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*) pdev->pClassData;
+	USBD_LL_OpenEP(pdev, GSUSB_ENDPOINT_IN, USBD_EP_TYPE_BULK, CAN_DATA_MAX_PACKET_SIZE);
+	USBD_LL_OpenEP(pdev, GSUSB_ENDPOINT_OUT, USBD_EP_TYPE_BULK, CAN_DATA_MAX_PACKET_SIZE);
+	hcan->from_host_buf = queue_pop_front(hcan->q_frame_pool);
+	USBD_GS_CAN_PrepareReceive(pdev);
+
+	return USBD_OK;
+
 }
 
 static uint8_t USBD_GS_CAN_DeInit(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
@@ -348,9 +340,11 @@ static uint8_t USBD_GS_CAN_SOF(struct _USBD_HandleTypeDef *pdev)
 
 void USBD_GS_CAN_SetChannel(USBD_HandleTypeDef *pdev, uint8_t channel, can_data_t* handle) {
 	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*) pdev->pClassData;
-	if ((hcan!=NULL) && (channel < NUM_CAN_CHANNEL)) {
-		hcan->channels[channel] = handle;
-	}
+
+	assert_basic(hcan);
+	assert_basic(channel < NUM_CAN_CHANNEL);
+	hcan->channels[channel] = handle;
+	return;
 }
 
 static led_seq_step_t led_identify_seq[] = {
@@ -615,7 +609,7 @@ static uint8_t USBD_GS_CAN_DataOut(USBD_HandleTypeDef *pdev, uint8_t epnum) {
 		if(frame){
 		        queue_push_back_i(hcan->q_from_host, hcan->from_host_buf);
 		        hcan->from_host_buf = frame;
-		  
+
 		        retval = USBD_OK;
 		}
 		else{
@@ -676,21 +670,22 @@ uint8_t USBD_GS_CAN_GetPadPacketsToMaxPacketSize(USBD_HandleTypeDef *pdev)
 
 uint8_t USBD_GS_CAN_SendFrame(USBD_HandleTypeDef *pdev, struct gs_host_frame *frame)
 {
-        uint8_t buf[CAN_DATA_MAX_PACKET_SIZE],*send_addr;
-  
+	uint8_t buf[CAN_DATA_MAX_PACKET_SIZE],*send_addr;
+
 	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*)pdev->pClassData;
 	size_t len = sizeof(struct gs_host_frame);
 
-	if (!hcan->timestamps_enabled)
-	  len -= 4;
+	if (!hcan->timestamps_enabled) {
+		len -= 4;
+	}
 
 	send_addr = (uint8_t *)frame;
-	
+
 	if(hcan->pad_pkts_to_max_pkt_size){
-	        // When talking to WinUSB it seems to help a lot if the
+		// When talking to WinUSB it seems to help a lot if the
 		// size of packet you send equals the max packet size.
-	        // In this mode, fill packets out to max packet size and
-	        // then send.
+		// In this mode, fill packets out to max packet size and
+		// then send.
 		memcpy(buf, frame, len);
 
 		// zero rest of buffer
@@ -698,7 +693,7 @@ uint8_t USBD_GS_CAN_SendFrame(USBD_HandleTypeDef *pdev, struct gs_host_frame *fr
 		send_addr = buf;
 		len = sizeof(buf);
 	}
-   
+
 	return USBD_GS_CAN_Transmit(pdev, send_addr, len);
 }
 

--- a/src/util.c
+++ b/src/util.c
@@ -25,6 +25,7 @@ THE SOFTWARE.
 */
 
 #include <util.h>
+#include <cmsis_device.h>
 
 void hex32(char *out, uint32_t val)
 {
@@ -43,4 +44,9 @@ void hex32(char *out, uint32_t val)
 		val >>= 4;
 		p--;
 	}
+}
+
+void assert_failed(void) {
+	/* for now, just halt and trigger debugger (if attached) */
+	__BKPT(0);
 }


### PR DESCRIPTION
Avoid using <assert.h> because the standard assert() pulls in
fprintf and its dependencies, as well as including ` __FILE__:__LINE__`
strings for each assert() call. All this has an unacceptable memory
cost, as well as being useless since there is nowhere to printf *to*.

Currently assert_basic() was added to check calloc() return values;
in case of failure we simply halt the core with BKPT(0). This could be
improved and refined.

@brian-brt , @normaldotcom , thoughts / comments ?