### PR TITLE
Add git version string to USB config descriptor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,18 @@ add_subdirectory(libs/STM32_HAL)
 add_subdirectory(libs/STM32_USB_Device_Library)
 set( CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake )
 
+
+# Add a custom target that produces version.h, plus
+# a dummy output that's not actually produced, in order
+# to force version.hmake to always be re-run before the build
+
+
+add_custom_target(version_h BYPRODUCTS "${CMAKE_CURRENT_BINARY_DIR}/version.h"
+	COMMAND ${CMAKE_COMMAND}
+		-D SRCDIR="${CMAKE_CURRENT_SOURCE_DIR}"
+		-P ${CMAKE_CURRENT_SOURCE_DIR}/cmake/gitversion.cmake
+)
+
 set(
     SOURCE_FILES
         include/config.h
@@ -49,6 +61,8 @@ set(
         src/startup.c
         src/main.c
         src/interrupts.c
+
+        ${CMAKE_CURRENT_BINARY_DIR}/version.h
 )
 
 
@@ -102,7 +116,8 @@ endfunction()
 
 function(add_f042_target TGTNAME)
 	add_executable(${TGTNAME}_fw ${SOURCE_FILES})
-    target_include_directories(${TGTNAME}_fw PRIVATE include/)
+	add_dependencies(${TGTNAME}_fw version_h)
+    target_include_directories(${TGTNAME}_fw PRIVATE include/ ${CMAKE_CURRENT_BINARY_DIR})
     target_compile_definitions(${TGTNAME}_fw PRIVATE BOARD=BOARD_${TGTNAME})
 	target_link_options(${TGTNAME}_fw PRIVATE -T ${CMAKE_SOURCE_DIR}/ldscripts/STM32F042X6.ld)
     target_link_libraries(${TGTNAME}_fw PRIVATE STM32_HAL_STM32F042x6 STM32_USB_Device_Library_STM32F042x6)
@@ -113,7 +128,8 @@ endfunction()
 
 function(add_f072_target TGTNAME)
 	add_executable(${TGTNAME}_fw ${SOURCE_FILES})
-    target_include_directories(${TGTNAME}_fw PRIVATE include/)
+	add_dependencies(${TGTNAME}_fw version_h)
+    target_include_directories(${TGTNAME}_fw PRIVATE include/ ${CMAKE_CURRENT_BINARY_DIR})
     target_compile_definitions(${TGTNAME}_fw PRIVATE BOARD=BOARD_${TGTNAME})
 	target_link_options(${TGTNAME}_fw PRIVATE -T ${CMAKE_SOURCE_DIR}/ldscripts/STM32F072XB.ld)
     target_link_libraries(${TGTNAME}_fw PRIVATE STM32_HAL_STM32F072xB STM32_USB_Device_Library_STM32F072xB)

--- a/cmake/gitversion.cmake
+++ b/cmake/gitversion.cmake
@@ -1,0 +1,52 @@
+# source: adapted from
+# https://www.mattkeeter.com/blog/2018-01-06-versioning/
+
+find_package(Git)
+
+# quoting in execute_process is fragile... cmake encloses every arg with ' ' , but adding any kind of quoting to
+# e.g. add spaces in the format string, will not work easily.
+
+if (Git_FOUND)
+	execute_process(COMMAND ${GIT_EXECUTABLE} log --pretty=format:fw_%h_%as -n 1
+		OUTPUT_VARIABLE GIT_REV
+		ERROR_QUIET
+		WORKING_DIRECTORY ${SRCDIR}
+	)
+endif()
+
+# Check whether we got any revision (which isn't
+# always the case, e.g. when someone downloaded a zip
+# file from Github instead of a checkout)
+if ("${GIT_REV}" STREQUAL "")
+    set(GIT_REV "N/A")
+    set(GIT_DIFF "")
+    set(GIT_TAG "N/A")
+else()
+    execute_process(
+		COMMAND ${GIT_EXECUTABLE} diff --quiet --exit-code
+		RESULT_VARIABLE GIT_DIRTY
+		WORKING_DIRECTORY ${SRCDIR})
+    execute_process(
+        COMMAND git describe --exact-match --tags
+        OUTPUT_VARIABLE GIT_TAG
+		ERROR_QUIET
+		WORKING_DIRECTORY ${SRCDIR})
+	if (NOT "${GIT_DIRTY}" EQUAL 0)
+		#append '+' if unclean tree
+		set(GIT_DIFF "+")
+	endif()
+
+    string(STRIP "${GIT_REV}" GIT_REV)
+endif()
+
+set(VERSION "#define GIT_HASH \"${GIT_REV}${GIT_DIFF}\"\n")
+
+if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/version.h)
+    file(READ ${CMAKE_CURRENT_SOURCE_DIR}/version.h VERSION_)
+else()
+    set(VERSION_ "")
+endif()
+
+if (NOT "${VERSION}" STREQUAL "${VERSION_}")
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/version.h "${VERSION}")
+endif()

--- a/include/config.h
+++ b/include/config.h
@@ -26,12 +26,14 @@ THE SOFTWARE.
 
 #pragma once
 
+#include "version.h"
+
 #define CAN_QUEUE_SIZE 64
 
 #define USBD_VID                     0x1d50
 #define USBD_PID_FS                  0x606f
 #define USBD_LANGID_STRING           1033
-#define USBD_CONFIGURATION_STRING_FS (uint8_t*) "gs_usb config"
+#define USBD_CONFIGURATION_STRING_FS (uint8_t*) GIT_HASH
 #define USBD_INTERFACE_STRING_FS     (uint8_t*) "gs_usb interface"
 
 #define BOARD_candleLight 1

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -107,7 +107,7 @@ static const uint8_t USBD_GS_CAN_CfgDesc[USB_CAN_CONFIG_DESC_SIZ] =
 	0x00,
 	0x02,                             /* bNumInterfaces */
 	0x01,                             /* bConfigurationValue */
-	0x00,                             /* iConfiguration */
+	USBD_IDX_CONFIG_STR,              /* iConfiguration */
 	0x80,                             /* bmAttributes */
 	0x4B,                             /* MaxPower 150 mA */
 	/*---------------------------------------------------------------------------*/


### PR DESCRIPTION
There was already provisions for this in the code. Tweaked CMake to
generate version.h automatically every build.

This is my proposal for #29 , adding build/version info to USB descriptors.

and under linux, the version string can be seen with lsusb -v  :

```
 iProduct                2 cannette gs_usb
  iSerial                 3 003300264250431420363230
  bNumConfigurations      1
  Configuration Descriptor:
    bLength                 9
    bDescriptorType         2
    wTotalLength       0x0032
    bNumInterfaces          2
    bConfigurationValue     1
    iConfiguration          4 fw_138e6cb_2021-02-17+
    bmAttributes         0x80
      (Bus Powered)
```