### PR TITLE
Document CAN-FD support

### DIFF
--- a/include/gs_usb.h
+++ b/include/gs_usb.h
@@ -39,7 +39,8 @@ THE SOFTWARE.
 #define GS_CAN_MODE_TRIPLE_SAMPLE               (1<<2)
 #define GS_CAN_MODE_ONE_SHOT                    (1<<3)
 #define GS_CAN_MODE_HW_TIMESTAMP                (1<<4)
-
+/* #define GS_CAN_FEATURE_IDENTIFY              (1<<5) */
+/* #define GS_CAN_FEATURE_USER_ID               (1<<6) */
 #define GS_CAN_MODE_PAD_PKTS_TO_MAX_PKT_SIZE    (1<<7)
 
 #define GS_CAN_FEATURE_LISTEN_ONLY              (1<<0)

--- a/include/gs_usb.h
+++ b/include/gs_usb.h
@@ -44,6 +44,7 @@ THE SOFTWARE.
 #define GS_CAN_MODE_PAD_PKTS_TO_MAX_PKT_SIZE    (1<<7)
 #define GS_CAN_MODE_FD                          (1<<8) /* switch device to CAN-FD mode */
 /* #define GS_CAN_FEATURE_REQ_USB_QUIRK_LPC546XX (1<<9) */
+/* #define GS_CAN_FEATURE_BT_CONST_EXT          (1<<10) */
 
 #define GS_CAN_FEATURE_LISTEN_ONLY              (1<<0)
 #define GS_CAN_FEATURE_LOOP_BACK                (1<<1)
@@ -58,6 +59,11 @@ THE SOFTWARE.
  * let host driver add a padding byte to each USB frame
  */
 #define GS_CAN_FEATURE_REQ_USB_QUIRK_LPC546XX   (1<<9)
+/* device supports separate bit timing constants for CAN-FD
+ * arbitration and data phase, see:
+ * GS_USB_BREQ_BT_CONST_EXT and struct gs_device_bt_const_extended
+ */
+#define GS_CAN_FEATURE_BT_CONST_EXT             (1<<10)
 
 #define GS_CAN_FLAG_OVERFLOW                    (1<<0)
 #define GS_CAN_FLAG_FD                          (1<<1) /* is a CAN-FD frame */
@@ -156,6 +162,7 @@ enum gs_usb_breq {
 	GS_USB_BREQ_GET_USER_ID,
 	GS_USB_BREQ_SET_USER_ID,
 	GS_USB_BREQ_DATA_BITTIMING,
+	GS_USB_BREQ_BT_CONST_EXT,
 };
 
 enum gs_can_mode {
@@ -222,6 +229,28 @@ struct gs_device_bt_const {
 	u32 brp_min;
 	u32 brp_max;
 	u32 brp_inc;
+} __packed;
+
+struct gs_device_bt_const_extended {
+	u32 feature;
+	u32 fclk_can;
+	u32 tseg1_min;
+	u32 tseg1_max;
+	u32 tseg2_min;
+	u32 tseg2_max;
+	u32 sjw_max;
+	u32 brp_min;
+	u32 brp_max;
+	u32 brp_inc;
+
+	u32 dtseg1_min;
+	u32 dtseg1_max;
+	u32 dtseg2_min;
+	u32 dtseg2_max;
+	u32 dsjw_max;
+	u32 dbrp_min;
+	u32 dbrp_max;
+	u32 dbrp_inc;
 } __packed;
 
 struct gs_host_frame {

--- a/include/gs_usb.h
+++ b/include/gs_usb.h
@@ -42,6 +42,7 @@ THE SOFTWARE.
 /* #define GS_CAN_FEATURE_IDENTIFY              (1<<5) */
 /* #define GS_CAN_FEATURE_USER_ID               (1<<6) */
 #define GS_CAN_MODE_PAD_PKTS_TO_MAX_PKT_SIZE    (1<<7)
+#define GS_CAN_MODE_FD                          (1<<8) /* switch device to CAN-FD mode */
 
 #define GS_CAN_FEATURE_LISTEN_ONLY              (1<<0)
 #define GS_CAN_FEATURE_LOOP_BACK                (1<<1)
@@ -50,10 +51,13 @@ THE SOFTWARE.
 #define GS_CAN_FEATURE_HW_TIMESTAMP             (1<<4)
 #define GS_CAN_FEATURE_IDENTIFY                 (1<<5)
 #define GS_CAN_FEATURE_USER_ID                  (1<<6)
-
 #define GS_CAN_FEATURE_PAD_PKTS_TO_MAX_PKT_SIZE (1<<7)
+#define GS_CAN_FEATURE_FD                       (1<<8) /* device supports CAN-FD */
 
-#define GS_CAN_FLAG_OVERFLOW 1
+#define GS_CAN_FLAG_OVERFLOW                    (1<<0)
+#define GS_CAN_FLAG_FD                          (1<<1) /* is a CAN-FD frame */
+#define GS_CAN_FLAG_BRS                         (1<<2) /* bit rate switch (for CAN-FD frames) */
+#define GS_CAN_FLAG_ESI                         (1<<3) /* error state indicator (for CAN-FD frames) */
 
 #define CAN_EFF_FLAG 0x80000000U /* EFF/SFF is set in the MSB */
 #define CAN_RTR_FLAG 0x40000000U /* remote transmission request */
@@ -146,6 +150,7 @@ enum gs_usb_breq {
 	GS_USB_BREQ_IDENTIFY,
 	GS_USB_BREQ_GET_USER_ID,
 	GS_USB_BREQ_SET_USER_ID,
+	GS_USB_BREQ_DATA_BITTIMING,
 };
 
 enum gs_can_mode {
@@ -227,6 +232,18 @@ struct gs_host_frame {
 
 	u32 timestamp_us;
 
+} __packed;
+
+struct gs_host_frame_canfd {
+	u32 echo_id;
+	u32 can_id;
+
+	u8 can_dlc;
+	u8 channel;
+	u8 flags;
+	u8 reserved;
+
+	u8 data[64];
 } __packed;
 
 struct gs_tx_context {

--- a/include/gs_usb.h
+++ b/include/gs_usb.h
@@ -43,6 +43,7 @@ THE SOFTWARE.
 /* #define GS_CAN_FEATURE_USER_ID               (1<<6) */
 #define GS_CAN_MODE_PAD_PKTS_TO_MAX_PKT_SIZE    (1<<7)
 #define GS_CAN_MODE_FD                          (1<<8) /* switch device to CAN-FD mode */
+/* #define GS_CAN_FEATURE_REQ_USB_QUIRK_LPC546XX (1<<9) */
 
 #define GS_CAN_FEATURE_LISTEN_ONLY              (1<<0)
 #define GS_CAN_FEATURE_LOOP_BACK                (1<<1)
@@ -53,6 +54,10 @@ THE SOFTWARE.
 #define GS_CAN_FEATURE_USER_ID                  (1<<6)
 #define GS_CAN_FEATURE_PAD_PKTS_TO_MAX_PKT_SIZE (1<<7)
 #define GS_CAN_FEATURE_FD                       (1<<8) /* device supports CAN-FD */
+/* request workaround for LPC546XX erratum USB.15:
+ * let host driver add a padding byte to each USB frame
+ */
+#define GS_CAN_FEATURE_REQ_USB_QUIRK_LPC546XX   (1<<9)
 
 #define GS_CAN_FLAG_OVERFLOW                    (1<<0)
 #define GS_CAN_FLAG_FD                          (1<<1) /* is a CAN-FD frame */


### PR DESCRIPTION
This PR documents the CAN-FD support that has been added to the `gs_usb` Linux driver and will hit mainline soon.

This paves the road for other CAN-FD capable STM32 µC to implement CAN-FD support to their firmware.