### PR TITLE
main: clear frame->{flags,reserved} of Echo Frames before sending back to host

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -114,6 +114,8 @@ int main(void)
 		if (frame != 0) { // send can message from host
 			if (can_send(&hCAN, frame)) {
 				// Echo sent frame back to host
+				frame->flags = 0x0;
+				frame->reserved = 0x0;
 				frame->timestamp_us = timer_get();
 				send_to_host_or_enqueue(frame);
 


### PR DESCRIPTION
The Linux driver doesn't clear the flags (and reserved) value of the
struct gs_host_frame send to the device.

With the Echo Frame this value gets send back to Linux und might be
interpreted as a GS_CAN_FLAG_OVERFLOW Error Frame. Clear the flags
value before echoing back. While there clear the reserved value, too.

Since the following patch, Linux clears the flags value before sending it:

| https://lore.kernel.org/all/20220106002952.25883-1-brian.silverman@bluerivertech.com

This patch fixes https://github.com/candle-usb/candleLight_fw/issues/87