### PR TITLE
Bugfix#46/fix can hang on host reboot

### DIFF
--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -65,6 +65,8 @@ extern USBD_ClassTypeDef USBD_GS_CAN;
 
 uint8_t USBD_GS_CAN_Init(USBD_HandleTypeDef *pdev, queue_t *q_frame_pool, queue_t *q_from_host, led_data_t *leds);
 void USBD_GS_CAN_SetChannel(USBD_HandleTypeDef *pdev, uint8_t channel, can_data_t* handle);
+void USBD_GS_CAN_SuspendCallback(USBD_HandleTypeDef  *pdev);
+void USBD_GS_CAN_ResumeCallback(USBD_HandleTypeDef  *pdev);
 bool USBD_GS_CAN_TxReady(USBD_HandleTypeDef *pdev);
 uint8_t USBD_GS_CAN_PrepareReceive(USBD_HandleTypeDef *pdev);
 bool USBD_GS_CAN_CustomDeviceRequest(USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef *req);

--- a/src/main.c
+++ b/src/main.c
@@ -48,13 +48,13 @@ void SystemClock_Config(void);
 static bool send_to_host_or_enqueue(struct gs_host_frame *frame);
 static void send_to_host();
 
-can_data_t hCAN;
-USBD_HandleTypeDef hUSB;
-led_data_t hLED;
+can_data_t hCAN = {0};
+USBD_HandleTypeDef hUSB = {0};
+led_data_t hLED = {0};
 
-queue_t *q_frame_pool;
-queue_t *q_from_host;
-queue_t *q_to_host;
+queue_t *q_frame_pool = NULL;
+queue_t *q_from_host = NULL;
+queue_t *q_to_host = NULL;
 
 uint32_t received_count=0;
 

--- a/src/usbd_conf.c
+++ b/src/usbd_conf.c
@@ -99,12 +99,14 @@ void HAL_PCD_ResetCallback(PCD_HandleTypeDef *hpcd)
 
 void HAL_PCD_SuspendCallback(PCD_HandleTypeDef *hpcd)
 {
+	USBD_GS_CAN_SuspendCallback((USBD_HandleTypeDef*)hpcd->pData);
 	USBD_LL_Suspend((USBD_HandleTypeDef*)hpcd->pData);
 }
 
 void HAL_PCD_ResumeCallback(PCD_HandleTypeDef *hpcd)
 {
 	USBD_LL_Resume((USBD_HandleTypeDef*) hpcd->pData);
+	USBD_GS_CAN_ResumeCallback((USBD_HandleTypeDef*)hpcd->pData);
 }
 
 USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev)

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -735,3 +735,27 @@ bool USBD_GS_CAN_DfuDetachRequested(USBD_HandleTypeDef *pdev)
 	return hcan->dfu_detach_requested;
 }
 
+// Handle USB suspend event
+void USBD_GS_CAN_SuspendCallback(USBD_HandleTypeDef  *pdev)
+{
+	// Disable CAN and go off bus on USB suspend
+	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*) pdev->pClassData;
+
+	if(hcan != NULL)
+	{
+		for(uint32_t i=0; i<NUM_CAN_CHANNEL; i++)
+		{
+			if(hcan->channels[i] != NULL)
+				can_disable(hcan->channels[i]);
+		}
+	}
+
+	if(hcan != NULL && hcan->leds != NULL)
+		led_set_mode(hcan->leds, led_mode_off);
+}
+
+void USBD_GS_CAN_ResumeCallback(USBD_HandleTypeDef  *pdev)
+{
+	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*) pdev->pClassData;
+	hcan->TxState = 0;
+}

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -313,11 +313,8 @@ static uint8_t USBD_GS_CAN_Start(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
 	UNUSED(cfgidx);
 
 	assert_basic(pdev->pClassData);
-
-	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*) pdev->pClassData;
 	USBD_LL_OpenEP(pdev, GSUSB_ENDPOINT_IN, USBD_EP_TYPE_BULK, CAN_DATA_MAX_PACKET_SIZE);
 	USBD_LL_OpenEP(pdev, GSUSB_ENDPOINT_OUT, USBD_EP_TYPE_BULK, CAN_DATA_MAX_PACKET_SIZE);
-	hcan->from_host_buf = queue_pop_front(hcan->q_frame_pool);
 	USBD_GS_CAN_PrepareReceive(pdev);
 
 	return USBD_OK;


### PR DESCRIPTION
After running a debugging session with I found two reasons for the can bus going to non responsive state when host reboots.

1. After the host reboot, the `USBD_GS_CAN_Start` function is called, In that we take a pointer out of frame pool and never pushes it back, So every time the host reboot, we leak a pointer one by one, also the `hcan` is not even utilised after taking out the pointer, looks like some old code that has not been cleaned up.
2. The second reason is hard to predict and that's why the occurrence of the issue was so random, It's because the resource lock on `hcan->TxState`, when host reboots, it's not guaranteed that the last msg sent will be delivered and the resource will be unlocked, hence unlocking on resume call back seemed to have tackle this problem. 

Now I have tested the code with this PR for about more than 24 hours where my host system reboots every 2 minute and it seems to be working fine. Cheers 