### PR TITLE
remove odd err-frames

### DIFF
--- a/include/can.h
+++ b/include/can.h
@@ -57,8 +57,6 @@ bool can_send(can_data_t *hcan, struct gs_host_frame *frame);
  */
 uint32_t can_get_error_status(can_data_t *hcan);
 
-#define CAN_ERRCOUNT_THRESHOLD 15   /* send an error frame if tx/rx counters increase by more than this amount */
-
 /** parse status value returned by can_get_error_status().
  * @param frame : will hold the generated error frame
  * @return 1 when status changes (if any) need a new error frame sent


### PR DESCRIPTION
The gusb-interface can report completely weird error-frames, like being in error-active (based on counters), and error-warning, and bus-off at the same time.
    
  To fix this:
    - only send state changes once.
    - don't send LEC / err counters in bus-off (invalid anyway).
    - don't send empty error frames.
    - remove triggering error message based on counter values / err counters in bus-off (invalid anyway).
    - don't send empty error frames.


