### PR TITLE
Add switchable terminating resistor support

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -29,8 +29,10 @@ THE SOFTWARE.
 * - LED pin assignments and polarity
 * - other special pins to control CAN transceivers.
 *
-* CAN_S_PIN :Some CAN transceivers (e.g. TJA1050) have a "Silent mode in which the transmitter is disabled";
+* CAN_S_PIN: Some CAN transceivers (e.g. TJA1050) have a "Silent mode in which the transmitter is disabled";
 * enabled with this 'S' pin. If undefined, the corresponding code will be disabled.
+*
+* TERM_Pin: Add support for an externally controlled terminating resistor
 *
 */
 
@@ -206,6 +208,11 @@ THE SOFTWARE.
 	#define USB_GPIO_Port	 GPIOA
 	#define USB_Pin_DM		 GPIO_PIN_11
 	#define USB_Pin_DP		 GPIO_PIN_12
+
+	#define TERM_GPIO_Port		GPIOB
+	#define TERM_Pin			GPIO_PIN_3
+	#define TERM_Mode			GPIO_MODE_OUTPUT_PP
+	#define TERM_Active_High	1
 
 #else
 	#error please define BOARD

--- a/include/gpio.h
+++ b/include/gpio.h
@@ -26,4 +26,27 @@ THE SOFTWARE.
 
 #pragma once
 
+#include "gs_usb.h"
+#include "config.h"
+
 void gpio_init(void);
+
+#ifdef TERM_Pin
+enum gs_can_termination_state set_term(unsigned int channel, enum gs_can_termination_state state);
+enum gs_can_termination_state get_term(unsigned int channel);
+
+#else
+static inline enum gs_can_termination_state set_term(unsigned int channel, enum gs_can_termination_state state)
+{
+	(void)channel;
+	(void)state;
+	return GS_CAN_TERMINATION_UNSUPPORTED;
+}
+
+static inline enum gs_can_termination_state get_term(unsigned int channel)
+{
+	(void)channel;
+	return GS_CAN_TERMINATION_UNSUPPORTED;
+}
+
+#endif

--- a/include/gs_usb.h
+++ b/include/gs_usb.h
@@ -26,6 +26,7 @@ THE SOFTWARE.
 
 #pragma once
 
+#include "hal_include.h"
 #define u32 uint32_t
 #define u8 uint8_t
 
@@ -188,6 +189,12 @@ enum gs_can_state {
 	GS_CAN_STATE_BUS_OFF,
 	GS_CAN_STATE_STOPPED,
 	GS_CAN_STATE_SLEEPING
+};
+
+enum gs_can_termination_state {
+	GS_CAN_TERMINATION_UNSUPPORTED = -1,	// private, not in kernel enum
+	GS_CAN_TERMINATION_STATE_OFF = 0,
+	GS_CAN_TERMINATION_STATE_ON,
 };
 
 /* data types passed between host and device */

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -24,10 +24,65 @@ THE SOFTWARE.
 
 */
 
-#include "config.h"
+#include "gpio.h"
 #include "hal_include.h"
 
 #define GPIO_INIT_STATE(ACTIVE_HIGH) (((ACTIVE_HIGH) == 1) ? GPIO_PIN_RESET : GPIO_PIN_SET)
+
+#ifdef TERM_Pin
+static int term_state = 0;
+
+enum gs_can_termination_state get_term(unsigned int channel)
+{
+	if (term_state & (1 << channel)) {
+		return GS_CAN_TERMINATION_STATE_ON;
+	} else {
+		return GS_CAN_TERMINATION_STATE_OFF;
+	}
+}
+
+enum gs_can_termination_state set_term(unsigned int channel, enum gs_can_termination_state state)
+{
+	if (state == GS_CAN_TERMINATION_STATE_ON) {
+		term_state |= 1 << channel;
+	} else {
+		term_state &= ~(1 << channel);
+	}
+
+#if (TERM_Active_High == 1)
+	#define TERM_ON  GPIO_PIN_SET
+	#define TERM_OFF GPIO_PIN_RESET
+#else
+	#define TERM_ON  GPIO_PIN_RESET
+	#define TERM_OFF GPIO_PIN_SET
+#endif
+
+	HAL_GPIO_WritePin(TERM_GPIO_Port, TERM_Pin, (state ? TERM_ON : TERM_OFF));
+
+	return state;
+}
+
+static inline void gpio_init_term(void)
+{
+	HAL_GPIO_WritePin(TERM_GPIO_Port, TERM_Pin, GPIO_INIT_STATE(TERM_Active_High));
+
+	GPIO_InitTypeDef GPIO_InitStruct = {
+		.Pin = TERM_Pin,
+		.Mode = TERM_Mode,
+		.Pull = GPIO_NOPULL,
+		.Speed = GPIO_SPEED_FREQ_LOW,
+		.Alternate = 0
+	};
+	HAL_GPIO_Init(TERM_GPIO_Port, &GPIO_InitStruct);
+}
+
+#else
+
+static inline void gpio_init_term(void)
+{
+}
+
+#endif
 
 // must run before can_init
 void gpio_init(void)
@@ -102,4 +157,6 @@ void gpio_init(void)
 	GPIO_InitStruct.Alternate = GPIO_AF10_OTG_FS;
 	HAL_GPIO_Init(USB_GPIO_Port, &GPIO_InitStruct);
 #endif
+
+	gpio_init_term();
 }

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -34,6 +34,7 @@ THE SOFTWARE.
 #include "usbd_ioreq.h"
 #include "gs_usb.h"
 #include "can.h"
+#include "gpio.h"
 #include "timer.h"
 #include "flash.h"
 
@@ -272,7 +273,11 @@ static const struct gs_device_bt_const USBD_GS_CAN_btconst = {
 	| GS_CAN_FEATURE_HW_TIMESTAMP
 	| GS_CAN_FEATURE_IDENTIFY
 	| GS_CAN_FEATURE_USER_ID
-	| GS_CAN_FEATURE_PAD_PKTS_TO_MAX_PKT_SIZE,
+	| GS_CAN_FEATURE_PAD_PKTS_TO_MAX_PKT_SIZE
+#ifdef TERM_Pin
+	| GS_CAN_FEATURE_TERMINATION
+#endif
+	,
 	CAN_CLOCK_SPEED, // can timing base clock
 	1, // tseg1 min
 	16, // tseg1 max
@@ -383,6 +388,13 @@ static uint8_t USBD_GS_CAN_EP0_RxReady(USBD_HandleTypeDef *pdev) {
 			}
 			break;
 
+		case GS_USB_BREQ_SET_TERMINATION:
+			memcpy(&param_u32, hcan->ep0_buf, sizeof(param_u32));
+			if (set_term(req->wValue, param_u32) == GS_CAN_TERMINATION_UNSUPPORTED) {
+				USBD_CtlError(pdev, req);
+			}
+			break;
+
 		case GS_USB_BREQ_SET_USER_ID:
 			memcpy(&param_u32, hcan->ep0_buf, sizeof(param_u32));
 			if (flash_set_user_id(req->wValue, param_u32)) {
@@ -468,10 +480,17 @@ static uint8_t USBD_GS_CAN_DFU_Request(USBD_HandleTypeDef *pdev, USBD_SetupReqTy
 static uint8_t USBD_GS_CAN_Config_Request(USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef *req)
 {
 	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*) pdev->pClassData;
+	enum gs_can_termination_state term_state;
 	uint32_t d32;
 
 	switch (req->bRequest) {
 
+		case GS_USB_BREQ_SET_TERMINATION:
+			if (get_term(req->wValue) == GS_CAN_TERMINATION_UNSUPPORTED) {
+				USBD_CtlError(pdev, req);
+				break;
+			}
+		// fall-through
 		case GS_USB_BREQ_HOST_FORMAT:
 		case GS_USB_BREQ_MODE:
 		case GS_USB_BREQ_BITTIMING:
@@ -479,6 +498,19 @@ static uint8_t USBD_GS_CAN_Config_Request(USBD_HandleTypeDef *pdev, USBD_SetupRe
 		case GS_USB_BREQ_SET_USER_ID:
 			hcan->last_setup_request = *req;
 			USBD_CtlPrepareRx(pdev, hcan->ep0_buf, req->wLength);
+			break;
+
+		case GS_USB_BREQ_GET_TERMINATION:
+			term_state = get_term(req->wValue);
+
+			if (term_state == GS_CAN_TERMINATION_UNSUPPORTED) {
+				USBD_CtlError(pdev, req);
+			} else {
+				d32 = (uint32_t)term_state;
+				memcpy(hcan->ep0_buf, &d32, sizeof(d32));
+				USBD_CtlSendData(pdev, hcan->ep0_buf, req->wLength);
+			}
+
 			break;
 
 		case GS_USB_BREQ_DEVICE_CONFIG:
@@ -738,7 +770,7 @@ void USBD_GS_CAN_SuspendCallback(USBD_HandleTypeDef  *pdev)
 
 	if(hcan != NULL && hcan->leds != NULL)
 		led_set_mode(hcan->leds, led_mode_off);
-	
+
 	is_usb_suspend_cb = true;
 }
 


### PR DESCRIPTION
Add a USB message which controls a GPIO for a specified CAN bus. The GPIO activates a SSR to connect a 120Ohm terminating resistor
  to the specified CAN bus.

Signed-off-by: Daniel Trevitz <daniel.trevitz@wika.com>