### PR TITLE
Check code formatting on PR

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,18 @@
+name: PR
+
+on: [ pull_request ]
+
+jobs:
+  cpp_style_check:
+    runs-on: ubuntu-latest
+    name: Check C Styling
+    steps:
+    - name: Checkout this commit
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+    - name: uncrustify check
+      uses: Daniel-Trevitz/uncrustify-check@v1
+      with:
+        configFile: 'uncrustify.cfg'
+        checkedPaths: 'src;include'


### PR DESCRIPTION
Check the code formatting of a PR by looking up the files in git diff HEAD^
If the uncrustify config sees a change, yell about it.

The existing examples to uncrustify did not seem to work, so I forked and got it working.
 
In addition, this adds a directory filter, so we can safely ignore anything except the project's source and headers. 