### PR TITLE
Prepare for stm32g0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,15 @@
 /.vscode/
+/Debug/
 /build/
 *.asmo
 *.bin
 *.d
 *.elf
+*.launch
 *.o
 *~
 .cache/
+.cproject
+.project
+.settings
 compile_commands.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,10 @@
 /.vscode/
 /build/
-*.o
-*.d
-*.bin
 *.asmo
+*.bin
+*.d
 *.elf
+*.o
 *~
 .cache/
 compile_commands.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,26 +165,25 @@ endfunction()
 
 ########## generate list of targets.
 # the "_fw" part is appended automatically
-set(TGT042_LIST "cantact" "canalyze" "canable" "usb2can" "cannette")
-set(TGT072_LIST "candleLight" "CANable_MKS")
-set(TGT407_LIST "STM32F4_DevBoard")
+set(TGTF042_LIST "cantact" "canalyze" "canable" "usb2can" "cannette")
+set(TGTF072_LIST "candleLight" "CANable_MKS")
+set(TGTF407_LIST "STM32F4_DevBoard")
 
-
-foreach (TGTNAME IN LISTS TGT042_LIST)
+foreach (TGTNAME IN LISTS TGTF042_LIST)
 	option(BUILD_${TGTNAME} "Build firmware for \"${TGTNAME}\" (default=yes)" ON)
 	if (BUILD_${TGTNAME})
 		add_f042_target(${TGTNAME})
 	endif()
 endforeach()
 
-foreach (TGTNAME IN LISTS TGT072_LIST)
+foreach (TGTNAME IN LISTS TGTF072_LIST)
 	option(BUILD_${TGTNAME} "Build firmware for \"${TGTNAME}\" (default=yes)" ON)
 	if (BUILD_${TGTNAME})
 		add_f072_target(${TGTNAME})
 	endif()
 endforeach()
 
-foreach (TGTNAME IN LISTS TGT407_LIST)
+foreach (TGTNAME IN LISTS TGTF407_LIST)
 	option(BUILD_${TGTNAME} "Build firmware for \"${TGTNAME}\" (default=yes)" ON)
 	if (BUILD_${TGTNAME})
 		add_f407_target(${TGTNAME})

--- a/include/config.h
+++ b/include/config.h
@@ -52,6 +52,10 @@ THE SOFTWARE.
 	#define USBD_PRODUCT_STRING_FS	 (uint8_t*) "candleLight USB to CAN adapter"
 	#define USBD_MANUFACTURER_STRING (uint8_t*) "bytewerk"
 	#define DFU_INTERFACE_STRING_FS	 (uint8_t*) "candleLight firmware upgrade interface"
+
+	#define CAN_INTERFACE			 CAN
+	#define CAN_CLOCK_SPEED			 48000000
+
 	#define CAN_S_Pin				 GPIO_PIN_13
 	#define CAN_S_GPIO_Port			 GPIOC
 
@@ -70,6 +74,9 @@ THE SOFTWARE.
 	#define USBD_MANUFACTURER_STRING (uint8_t*) "makerbase"
 	#define DFU_INTERFACE_STRING_FS	 (uint8_t*) "CANable-MKS firmware upgrade interface"
 
+	#define CAN_INTERFACE			 CAN
+	#define CAN_CLOCK_SPEED			 48000000
+
 // SILENT pin not connected
 
 	#define LEDRX_GPIO_Port	  GPIOA
@@ -86,6 +93,9 @@ THE SOFTWARE.
 	#define USBD_PRODUCT_STRING_FS	 (uint8_t*) "cantact gs_usb"
 	#define USBD_MANUFACTURER_STRING (uint8_t*) "cantact.io"
 	#define DFU_INTERFACE_STRING_FS	 (uint8_t*) "cantact firmware upgrade interface"
+
+	#define CAN_INTERFACE			 CAN
+	#define CAN_CLOCK_SPEED			 48000000
 
 // SILENT pin not connected
 
@@ -104,6 +114,9 @@ THE SOFTWARE.
 	#define USBD_MANUFACTURER_STRING (uint8_t*) "canable.io"
 	#define DFU_INTERFACE_STRING_FS	 (uint8_t*) "canable firmware upgrade interface"
 
+	#define CAN_INTERFACE			 CAN
+	#define CAN_CLOCK_SPEED			 48000000
+
 // SILENT pin not connected
 
 	#define LEDRX_GPIO_Port	  GPIOB
@@ -120,6 +133,9 @@ THE SOFTWARE.
 	#define USBD_PRODUCT_STRING_FS	 (uint8_t*) "USB2CAN RCA gs_usb"
 	#define USBD_MANUFACTURER_STRING (uint8_t*) "Roboter Club Aachen"
 	#define DFU_INTERFACE_STRING_FS	 (uint8_t*) "usb2can firmware upgrade interface"
+
+	#define CAN_INTERFACE			 CAN
+	#define CAN_CLOCK_SPEED			 48000000
 
 // SILENT pin not connected
 
@@ -148,6 +164,9 @@ THE SOFTWARE.
 	#define USBD_MANUFACTURER_STRING (uint8_t*) "STMicroelectronics"
 	#define DFU_INTERFACE_STRING_FS	 (uint8_t*) "CANAlyze firmware upgrade interface"
 
+	#define CAN_INTERFACE			 CAN
+	#define CAN_CLOCK_SPEED			 48000000
+
 // SILENT pin not connected
 
 	#define LEDRX_GPIO_Port	  GPIOB
@@ -164,6 +183,9 @@ THE SOFTWARE.
 	#define USBD_PRODUCT_STRING_FS	 (uint8_t*) "cannette gs_usb"
 	#define USBD_MANUFACTURER_STRING (uint8_t*) "chacaltech"
 	#define DFU_INTERFACE_STRING_FS	 (uint8_t*) "cannette firmware upgrade interface"
+
+	#define CAN_INTERFACE			 CAN
+	#define CAN_CLOCK_SPEED			 48000000
 
 // SILENT pin not connected
 
@@ -191,6 +213,9 @@ THE SOFTWARE.
 	#define USBD_PRODUCT_STRING_FS	 (uint8_t*) "STM32F4VE Dev Board"
 	#define USBD_MANUFACTURER_STRING (uint8_t*) "misc"
 	#define DFU_INTERFACE_STRING_FS	 (uint8_t*) "STM32F4VE firmware upgrade interface"
+
+	#define CAN_INTERFACE			 CAN1
+	#define CAN_CLOCK_SPEED			 42000000
 
 	#define CAN_S_Pin				 GPIO_PIN_10
 	#define CAN_S_GPIO_Port			 GPIOA

--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -48,15 +48,11 @@ extern USBD_ClassTypeDef USBD_GS_CAN;
 
 
 #if defined(STM32F0)
-# define USB_INTERFACE	 USB
-# define USB_INTERRUPT	 USB_IRQn
-# define CAN_INTERFACE	 CAN
-# define CAN_CLOCK_SPEED 48000000
+# define USB_INTERFACE USB
+# define USB_INTERRUPT USB_IRQn
 #elif defined(STM32F4)
-# define USB_INTERFACE	 USB_OTG_FS
-# define USB_INTERRUPT	 OTG_FS_IRQn
-# define CAN_INTERFACE	 CAN1
-# define CAN_CLOCK_SPEED 42000000
+# define USB_INTERFACE USB_OTG_FS
+# define USB_INTERRUPT OTG_FS_IRQn
 
 // RX FIFO is defined in words, so divide bytes by 4
 // RX FIFO size chosen according to reference manual RM0368 which suggests


### PR DESCRIPTION
Take the first non STM32G0 specific patches from https://github.com/candle-usb/candleLight_fw/pull/126 and clean them up.