### PR TITLE
queue: remove unused functionality

### DIFF
--- a/include/queue.h
+++ b/include/queue.h
@@ -36,16 +36,7 @@ typedef struct {
 } queue_t;
 
 queue_t *queue_create(unsigned max_elements);
-void queue_free(queue_t *q);
 
-unsigned queue_size(queue_t *q);
-bool queue_is_empty(queue_t *q);
 bool queue_push_back(queue_t *q, void *el);
 bool queue_push_front(queue_t *q, void *el);
 void *queue_pop_front(queue_t *q);
-
-unsigned queue_size_i(queue_t *q);
-bool queue_is_empty_i(queue_t *q);
-bool queue_push_back_i(queue_t *q, void *el);
-bool queue_push_front_i(queue_t *q, void *el);
-void *queue_pop_front_i(queue_t *q);

--- a/src/queue.c
+++ b/src/queue.c
@@ -36,25 +36,6 @@ queue_t *queue_create(unsigned max_elements){
 	return q;
 }
 
-void queue_destroy(queue_t *q)
-{
-	free(q->buf);
-	free(q);
-}
-
-unsigned queue_size(queue_t *q)
-{
-	bool was_irq_enabled = disable_irq();
-	unsigned retval = q->size;
-	restore_irq(was_irq_enabled);
-	return retval;
-}
-
-bool queue_is_empty(queue_t *q)
-{
-	return queue_size(q)==0;
-}
-
 bool queue_push_back(queue_t *q, void *el)
 {
 	bool retval = false;
@@ -99,56 +80,5 @@ void *queue_pop_front(queue_t *q)
 		q->size -= 1;
 	}
 	restore_irq(was_irq_enabled);
-	return el;
-}
-
-unsigned queue_size_i(queue_t *q)
-{
-	return q->size;
-}
-
-bool queue_is_empty_i(queue_t *q)
-{
-	return queue_size_i(q)==0;
-}
-
-bool queue_push_back_i(queue_t *q, void *el)
-{
-	bool retval = false;
-
-	if (q->size < q->max_elements) {
-		unsigned pos = (q->first + q->size) % q->max_elements;
-		q->buf[pos] = el;
-		q->size += 1;
-		retval = true;
-	}
-
-	return retval;
-}
-
-bool queue_push_front_i(queue_t *q, void *el)
-{
-	bool retval = false;
-	if (q->size < q->max_elements) {
-		if (q->first==0) {
-			q->first = q->max_elements - 1;
-		} else {
-			q->first = q->first - 1;
-		}
-		q->buf[q->first] = el;
-		q->size += 1;
-		retval = true;
-	}
-	return retval;
-}
-
-void *queue_pop_front_i(queue_t *q)
-{
-	void *el = 0;
-	if (q->size > 0) {
-		el = q->buf[q->first];
-		q->first = (q->first + 1) % q->max_elements;
-		q->size -= 1;
-	}
 	return el;
 }


### PR DESCRIPTION
Looking at the queue code it turns out, a lot of the functions are not used. Remove the unused queue functionality. Not sure why the compiler hasn't removed the `malloc()` and `free()` functions entirely, but this saves some bytes:

```
| add/remove: 0/3 grow/shrink: 0/0 up/down: 0/-232 (-232)
| Function                                     old     new   delta
| malloc                                        20       -     -20
| free                                          20       -     -20
| _free_r                                      192       -    -192
| Total: Before=17370, After=17138, chg -1.34%
```