### PR TITLE
editorconfig: add minimal editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+indent_size = 4
+indent_style = tab
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[lib/**]
+indent_size = 2
+indent_style = space


### PR DESCRIPTION
GH parses the `.editorconfig` for displaying code. Add minimal editorconfig to display our code, the STM code looks good at first glance, too.