### PR TITLE
startup: get rid of zero table and fix copy_table

### DIFF
--- a/ldscripts/STM32F042X6.ld
+++ b/ldscripts/STM32F042X6.ld
@@ -62,13 +62,6 @@ SECTIONS
     __copy_table_end__ = .;
   } > FLASH
 
-  .zero.table :
-  {
-    . = ALIGN(4);
-    __zero_table_start__ = .;
-    __zero_table_end__ = .;
-  } > FLASH
-
   __etext = ALIGN (4);
 
   .data : AT (__etext)

--- a/ldscripts/STM32F072XB.ld
+++ b/ldscripts/STM32F072XB.ld
@@ -63,13 +63,6 @@ SECTIONS
     __copy_table_end__ = .;
   } > FLASH
 
-  .zero.table :
-  {
-    . = ALIGN(4);
-    __zero_table_start__ = .;
-    __zero_table_end__ = .;
-  } > FLASH
-
   __etext = ALIGN (4);
 
 

--- a/ldscripts/STM32F407XE.ld
+++ b/ldscripts/STM32F407XE.ld
@@ -63,13 +63,6 @@ SECTIONS
     __copy_table_end__ = .;
   } > FLASH
 
-  .zero.table :
-  {
-    . = ALIGN(4);
-    __zero_table_start__ = .;
-    __zero_table_end__ = .;
-  } > FLASH
-
   __etext = ALIGN (4);
 
   .data : AT (__etext)

--- a/ldscripts/STM32G0B1XK.ld
+++ b/ldscripts/STM32G0B1XK.ld
@@ -62,13 +62,6 @@ SECTIONS
     __copy_table_end__ = .;
   } > FLASH
 
-  .zero.table :
-  {
-    . = ALIGN(4);
-    __zero_table_start__ = .;
-    __zero_table_end__ = .;
-  } > FLASH
-
   __etext = ALIGN (4);
 
   .data : AT (__etext)

--- a/src/startup.c
+++ b/src/startup.c
@@ -1,5 +1,6 @@
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
+#include <string.h>
 
 typedef struct _copy_table_t
 {
@@ -8,16 +9,8 @@ typedef struct _copy_table_t
 	uint32_t wlen;
 } copy_table_t;
 
-typedef struct _zero_table_t
-{
-	uint32_t* dest;
-	uint32_t wlen;
-} zero_table_t;
-
 extern const copy_table_t __copy_table_start__;
 extern const copy_table_t __copy_table_end__;
-extern const zero_table_t __zero_table_start__;
-extern const zero_table_t __zero_table_end__;
 
 void __initialize_hardware_early(void);
 void _start(void) __attribute__((noreturn));
@@ -27,20 +20,7 @@ void Reset_Handler(void)
 	__initialize_hardware_early();
 
 	for (copy_table_t const* table = &__copy_table_start__; table < &__copy_table_end__; ++table)
-	{
-		for (size_t i=0; i<table->wlen; ++i)
-		{
-			table->dest[i] = table->src[i];
-		}
-	}
-
-	for (zero_table_t const* table = &__zero_table_start__; table < &__zero_table_end__; ++table)
-	{
-		for (size_t i=0; i<table->wlen; ++i)
-		{
-			table->dest[i] = 0u;
-		}
-	}
+		memcpy(table->dest, table->src, table->wlen);
 
 	_start();
 }


### PR DESCRIPTION
Works for me on the STM32F072, can someone test the 042?

Should fix the this issue: https://github.com/candle-usb/candleLight_fw/pull/135#issuecomment-1317912852