### PR TITLE
cmake: switch from -Os to -O2 optimization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 add_compile_options(
 	--specs=nano.specs
 	--specs=nosys.specs
-	-Os
+	-O2
 	-Wall
 	-Werror
 	-Wextra
@@ -17,7 +17,6 @@ add_compile_options(
 	-ffunction-sections
 	-flto
 	-fmessage-length=0
-	-fno-move-loop-invariants
 	-fsigned-char
 	-g3
 	-mthumb


### PR DESCRIPTION
This increases the code size, but even on a STMF042 fits into the flash:

-Os
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       14180 B        32 KB     43.27%
             RAM:        3744 B         6 KB     60.94%
```

-O2
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       17284 B        32 KB     52.75%
             RAM:        3744 B         6 KB     60.94%
```

This optimization increases the max TX CAN bus load on a STM32F072 (1 MBit/s, DLC=1) from 77% to 84%.

For completeness:

-O3
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       22568 B        32 KB     68.87%
             RAM:        3744 B         6 KB     60.94%
```
The max TX CAN bus load is 88%.