### PR TITLE
LED performance rework

### DIFF
--- a/include/led.h
+++ b/include/led.h
@@ -29,6 +29,9 @@ THE SOFTWARE.
 #include <stdint.h>
 #include <stdbool.h>
 
+
+#define LED_UPDATE_INTERVAL 10  // number of ticks from HAL_GetTick
+
 typedef enum {
 	led_mode_off,
 	led_mode_normal,

--- a/include/led.h
+++ b/include/led.h
@@ -62,7 +62,6 @@ typedef struct {
 
 typedef struct {
 	led_mode_t mode;
-	led_mode_t last_mode;
 
 	const led_seq_step_t *sequence;
 	uint32_t sequence_step;

--- a/include/led.h
+++ b/include/led.h
@@ -54,6 +54,8 @@ typedef struct {
 	void* port;
 	uint16_t pin;
 	bool is_active_high;
+
+	bool blink_request;
 	uint32_t on_until;
 	uint32_t off_until;
 } led_state_t;

--- a/src/led.c
+++ b/src/led.c
@@ -85,23 +85,27 @@ void led_run_sequence(led_data_t *leds, const led_seq_step_t *sequence, int32_t 
 	led_update(leds);
 }
 
-void led_indicate_trx(led_data_t *leds, led_num_t num)
-{
-	uint32_t now = HAL_GetTick();
-	led_state_t *led = &leds->led_state[num];
+void led_indicate_trx(led_data_t *leds, led_num_t num) {
+	leds->led_state[num].blink_request = 1;
+}
 
-	if ( SEQ_ISPASSED(now, led->on_until) &&
-		 SEQ_ISPASSED(now, led->off_until) ) {
-		led->off_until = now + 30;
-		led->on_until = now + 45;
+static void led_trx_blinker(led_state_t *ledstate, uint32_t now) {
+	if ( SEQ_ISPASSED(now, ledstate->on_until) &&
+		 SEQ_ISPASSED(now, ledstate->off_until) ) {
+		ledstate->off_until = now + 30;
+		ledstate->on_until = now + 45;
 	}
-
-	led_update(leds);
 }
 
 static void led_update_normal_mode(led_state_t *led)
 {
 	uint32_t now = HAL_GetTick();
+
+	if (led->blink_request) {
+		led->blink_request = 0;
+		led_trx_blinker(led, now);
+	}
+
 	led_set(led, SEQ_ISPASSED(now, led->off_until));
 }
 

--- a/src/led.c
+++ b/src/led.c
@@ -137,6 +137,13 @@ static void led_update_sequence(led_data_t *leds)
 
 void led_update(led_data_t *leds)
 {
+	static uint32_t next_update = 0;
+	uint32_t now = HAL_GetTick();
+	if (!SEQ_ISPASSED(now, next_update)) {
+		return;
+	}
+	next_update = now + LED_UPDATE_INTERVAL;
+
 	switch (leds->mode) {
 
 		case led_mode_off:

--- a/src/led.c
+++ b/src/led.c
@@ -77,7 +77,6 @@ static uint32_t led_set_sequence_step(led_data_t *leds, uint32_t step_num)
 
 void led_run_sequence(led_data_t *leds, const led_seq_step_t *sequence, int32_t num_repeat)
 {
-	leds->last_mode = leds->mode;
 	leds->mode = led_mode_sequence;
 	leds->sequence = sequence;
 	leds->seq_num_repeat = num_repeat;

--- a/src/led.c
+++ b/src/led.c
@@ -96,10 +96,8 @@ static void led_trx_blinker(led_state_t *ledstate, uint32_t now) {
 	}
 }
 
-static void led_update_normal_mode(led_state_t *led)
+static void led_update_normal_mode(led_state_t *led, uint32_t now)
 {
-	uint32_t now = HAL_GetTick();
-
 	if (led->blink_request) {
 		led->blink_request = 0;
 		led_trx_blinker(led, now);
@@ -157,8 +155,8 @@ void led_update(led_data_t *leds)
 			break;
 
 		case led_mode_normal:
-			led_update_normal_mode(&leds->led_state[led_rx]);
-			led_update_normal_mode(&leds->led_state[led_tx]);
+			led_update_normal_mode(&leds->led_state[led_rx], now);
+			led_update_normal_mode(&leds->led_state[led_tx], now);
 			break;
 
 		case led_mode_sequence:

--- a/src/led.c
+++ b/src/led.c
@@ -24,9 +24,11 @@ THE SOFTWARE.
 
 */
 
-#include "led.h"
 #include <string.h>
+
+#include "led.h"
 #include "hal_include.h"
+#include "util.h"
 
 #define SEQ_ISPASSED(now, target) ((int32_t) ((now) - (target)) >= 0)
 
@@ -161,7 +163,6 @@ void led_update(led_data_t *leds)
 			break;
 
 		default:
-			led_set(&leds->led_state[led_rx], false);
-			led_set(&leds->led_state[led_tx], true);
+			assert_failed();
 	}
 }


### PR DESCRIPTION
Sidequest from #143 - we're spending way too much time updating LEDs.

The most gain here is obtained from calling led_update() less often (every 10ms with this patch).

The commit changing the implementation of `led_indicate_trx()` showed surprisingly marginal gains - about 0.5% with a `cangen -L0 -g0 -p10 can0` benchmark.

can busload goes from ~ 12900 to 13120 frames/s with this PR.
