### PR TITLE
disable DCDC and Si86xx isolators on USB suspend 

### DIFF
--- a/include/gpio.h
+++ b/include/gpio.h
@@ -51,5 +51,8 @@ static inline enum gs_can_termination_state get_term(unsigned int channel)
 	(void)channel;
 	return GS_CAN_TERMINATION_UNSUPPORTED;
 }
-
 #endif
+
+void gpio_suspend(void);
+
+void gpio_resume(void);

--- a/src/gpio.c
+++ b/src/gpio.c
@@ -161,3 +161,21 @@ void gpio_init(void)
 
 	gpio_init_term();
 }
+
+void gpio_suspend(void) {
+#ifdef nSI86EN_Pin
+	HAL_GPIO_WritePin(nSI86EN_Port, nSI86EN_Pin, GPIO_PIN_SET);
+#endif
+#ifdef DCDCEN_Pin
+	HAL_GPIO_WritePin(DCDCEN_Port, DCDCEN_Pin, GPIO_PIN_RESET);
+#endif
+}
+
+void gpio_resume(void) {
+#ifdef DCDCEN_Pin
+	HAL_GPIO_WritePin(DCDCEN_Port, DCDCEN_Pin, GPIO_PIN_SET);
+#endif
+#ifdef nSI86EN_Pin
+	HAL_GPIO_WritePin(nSI86EN_Port, nSI86EN_Pin, GPIO_PIN_RESET);
+#endif
+}

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -735,6 +735,7 @@ void USBD_GS_CAN_SuspendCallback(USBD_HandleTypeDef  *pdev)
 	if (hcan != NULL && hcan->leds != NULL)
 		led_set_mode(hcan->leds, led_mode_off);
 
+	gpio_suspend();
 	is_usb_suspend_cb = true;
 }
 
@@ -742,5 +743,6 @@ void USBD_GS_CAN_ResumeCallback(USBD_HandleTypeDef  *pdev)
 {
 	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*) pdev->pClassData;
 	hcan->TxState = 0;
+	gpio_resume();
 	is_usb_suspend_cb = false;
 }


### PR DESCRIPTION
Reduces current consumption by a lot in USB_SUSPEND state on certain boards. On most targets this PR has no effect (the empty functions are compiled out)

It would take more work to meet USB specs ( 0.5mA !), but this helps on boards with a DCDC and galvanic isolation (Si86xx ICs are fairly power-hungry).

On a cannette board, suspend current is now 15mA (from 56mA at idle with no CAN traffic).

Further steps would be to bring the whole mcu into sleep, to be waked by USB events.