### PR TITLE
override __register_exitproc()

### DIFF
--- a/src/startup.c
+++ b/src/startup.c
@@ -26,6 +26,9 @@ void Reset_Handler(void)
 	_start();
 }
 
+void __register_exitproc(void) {
+	return;
+}
 
 void _exit(int code)
 {


### PR DESCRIPTION
atexit() is meaningless on this kind of embedded fw. Overriding this symbol saves a bunch of memory (384 B flash on cannette).

Ref:
https://sourceware.org/git/?p=newlib-cygwin.git;a=blob_plain;f=newlib/libc/stdlib/__atexit.c;hb=HEAD