### PR TITLE
WIP: Add support for STM32G0 with can split in separate file 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,7 @@ set(
 	include/usbd_gs_can.h src/usbd_gs_can.c
 	src/usbd_conf.c
 
-	include/can.h src/can.c
+  include/can.h
 	include/device.h
 	include/dfu.h src/dfu.c
 	include/gpio.h src/gpio.c
@@ -218,6 +218,7 @@ function(add_f042_target TGTNAME)
 	target_compile_options(${TGTNAME}_fw BEFORE PRIVATE ${CPUFLAGS_F0})
 	target_compile_definitions(${TGTNAME}_fw PRIVATE BOARD_${TGTNAME} STM32F0)
 	target_sources(${TGTNAME}_fw PRIVATE "src/device/device_f0.c")
+	target_sources(${TGTNAME}_fw PRIVATE "src/can.c")
 	target_link_options(${TGTNAME}_fw BEFORE PRIVATE ${CPUFLAGS_F0})
 	target_link_libraries(${TGTNAME}_fw PRIVATE STM32_HAL_STM32F042x6 STM32_USB_Device_Library_STM32F042x6)
 endfunction()
@@ -227,6 +228,7 @@ function(add_f072_target TGTNAME)
 	target_compile_options(${TGTNAME}_fw BEFORE PRIVATE ${CPUFLAGS_F0})
 	target_compile_definitions(${TGTNAME}_fw PRIVATE BOARD_${TGTNAME} STM32F0)
 	target_sources(${TGTNAME}_fw PRIVATE "src/device/device_f0.c")
+	target_sources(${TGTNAME}_fw PRIVATE "src/can.c")
 	target_link_options(${TGTNAME}_fw BEFORE PRIVATE ${CPUFLAGS_F0})
 	target_link_libraries(${TGTNAME}_fw PRIVATE STM32_HAL_STM32F072xB STM32_USB_Device_Library_STM32F072xB)
 
@@ -237,6 +239,7 @@ function(add_f407_target TGTNAME)
 	target_compile_definitions(${TGTNAME}_fw PRIVATE BOARD_${TGTNAME} STM32F4)
 	target_compile_options(${TGTNAME}_fw BEFORE PRIVATE ${CPUFLAGS_F4})
 	target_sources(${TGTNAME}_fw PRIVATE "src/device/device_f4.c")
+	target_sources(${TGTNAME}_fw PRIVATE "src/can.c")
 	target_link_options(${TGTNAME}_fw BEFORE PRIVATE ${CPUFLAGS_F4})
 	target_link_libraries(${TGTNAME}_fw PRIVATE STM32_HAL_STM32F407xE STM32_USB_Device_Library_STM32F407xE)
 endfunction()
@@ -246,6 +249,7 @@ function(add_g0b1_target TGTNAME)
 	target_compile_definitions(${TGTNAME}_fw PRIVATE BOARD_${TGTNAME} STM32G0)
 	target_compile_options(${TGTNAME}_fw BEFORE PRIVATE ${CPUFLAGS_G0})
 	target_sources(${TGTNAME}_fw PRIVATE "src/device/device_g0.c")
+	target_sources(${TGTNAME}_fw PRIVATE "src/device/can_g0.c")
 	target_link_options(${TGTNAME}_fw BEFORE PRIVATE ${CPUFLAGS_G0})
 	target_link_libraries(${TGTNAME}_fw PRIVATE STM32_HAL_STM32G0B1xK STM32_USB_Device_Library_STM32G0B1xK)
 endfunction()

--- a/include/can.h
+++ b/include/can.h
@@ -33,10 +33,10 @@ THE SOFTWARE.
 #include "hal_include.h"
 
 #if defined(FDCAN1)
-#define GS_HOST_FRAME gs_host_frame_canfd
+#define GS_HOST_FRAME		  gs_host_frame_canfd
 #define GS_HOST_FRAME_CLASSIC gs_host_frame
 #else
-#define GS_HOST_FRAME gs_host_frame
+#define GS_HOST_FRAME		  gs_host_frame
 #endif
 
 typedef struct {

--- a/include/can.h
+++ b/include/can.h
@@ -32,6 +32,8 @@ THE SOFTWARE.
 #include "gs_usb.h"
 #include "hal_include.h"
 
+#define GS_HOST_FRAME gs_host_frame
+
 typedef struct {
 	CAN_TypeDef *instance;
 	uint16_t brp;
@@ -46,10 +48,10 @@ void can_enable(can_data_t *hcan, bool loop_back, bool listen_only, bool one_sho
 void can_disable(can_data_t *hcan);
 bool can_is_enabled(can_data_t *hcan);
 
-bool can_receive(can_data_t *hcan, struct gs_host_frame *rx_frame);
+bool can_receive(can_data_t *hcan, struct GS_HOST_FRAME *rx_frame);
 bool can_is_rx_pending(can_data_t *hcan);
 
-bool can_send(can_data_t *hcan, struct gs_host_frame *frame);
+bool can_send(can_data_t *hcan, struct GS_HOST_FRAME *frame);
 
 /** return CAN->ESR register which contains tx/rx error counters and
  * LEC (last error code).
@@ -60,4 +62,4 @@ uint32_t can_get_error_status(can_data_t *hcan);
  * @param frame : will hold the generated error frame
  * @return 1 when status changes (if any) need a new error frame sent
  */
-bool can_parse_error_status(uint32_t err, uint32_t last_err, can_data_t *hcan, struct gs_host_frame *frame);
+bool can_parse_error_status(uint32_t err, uint32_t last_err, can_data_t *hcan, struct GS_HOST_FRAME *frame);

--- a/include/can.h
+++ b/include/can.h
@@ -32,7 +32,12 @@ THE SOFTWARE.
 #include "gs_usb.h"
 #include "hal_include.h"
 
+#if defined(FDCAN1)
+#define GS_HOST_FRAME gs_host_frame_canfd
+#define GS_HOST_FRAME_CLASSIC gs_host_frame
+#else
 #define GS_HOST_FRAME gs_host_frame
+#endif
 
 typedef struct {
 	CAN_TypeDef *instance;

--- a/include/can.h
+++ b/include/can.h
@@ -40,14 +40,22 @@ THE SOFTWARE.
 #endif
 
 typedef struct {
+#if defined(STM32G0)
+	FDCAN_HandleTypeDef channel;
+#else
 	CAN_TypeDef *instance;
+#endif
 	uint16_t brp;
 	uint8_t phase_seg1;
 	uint8_t phase_seg2;
 	uint8_t sjw;
 } can_data_t;
 
+#if defined(STM32G0)
+void can_init(can_data_t *hcan, FDCAN_GlobalTypeDef *instance);
+#else
 void can_init(can_data_t *hcan, CAN_TypeDef *instance);
+#endif
 bool can_set_bittiming(can_data_t *hcan, uint16_t brp, uint8_t phase_seg1, uint8_t phase_seg2, uint8_t sjw);
 void can_enable(can_data_t *hcan, bool loop_back, bool listen_only, bool one_shot);
 void can_disable(can_data_t *hcan);

--- a/include/config.h
+++ b/include/config.h
@@ -41,6 +41,7 @@ THE SOFTWARE.
 #include "version.h"
 
 #define CAN_QUEUE_SIZE				 64
+#define NUM_CAN_CHANNEL				 1
 
 #define USBD_VID					 0x1d50
 #define USBD_PID_FS					 0x606f
@@ -236,6 +237,7 @@ THE SOFTWARE.
 	#define CAN_INTERFACE			 FDCAN1
 	#define CAN_INTERFACE2			 FDCAN2
 	#define CAN_CLOCK_SPEED			 64000000
+	#undef  NUM_CAN_CHANNEL
 	#define NUM_CAN_CHANNEL			 2
 	#define CANFD_SUPPORT
 

--- a/include/device.h
+++ b/include/device.h
@@ -29,6 +29,9 @@ THE SOFTWARE.
 #include "can.h"
 #include "hal_include.h"
 
+// As G0 uses a separate file this is not needed
+#if !defined(STM32G0)
 void device_can_init(can_data_t *hcan, CAN_TypeDef *instance);
+#endif
 
 void device_sysclock_config(void);

--- a/include/gs_usb.h
+++ b/include/gs_usb.h
@@ -311,4 +311,7 @@ struct gs_host_frame_canfd {
 	u8 reserved;
 
 	u8 data[64];
+
+	u32 timestamp_us;
+
 } __packed __aligned(4);

--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -41,7 +41,6 @@ THE SOFTWARE.
 #define CAN_DATA_MAX_PACKET_SIZE 32    /* Endpoint IN & OUT Packet size */
 #define CAN_CMD_PACKET_SIZE		 64    /* Control Endpoint Packet size */
 #define USB_CAN_CONFIG_DESC_SIZ	 50
-#define NUM_CAN_CHANNEL			 1
 #define USBD_GS_CAN_VENDOR_CODE	 0x20
 #define DFU_INTERFACE_NUM		 1
 #define DFU_INTERFACE_STR_INDEX	 0xE0

--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -90,6 +90,9 @@ typedef struct {
 // RX FIFO size chosen according to reference manual RM0368 which suggests
 // using (largest packet size / 4) + 1
 # define USB_RX_FIFO_SIZE ((256U / 4U) + 1U)
+#elif defined(STM32G0)
+# define USB_INTERFACE USB_DRD_FS
+# define USB_INTERRUPT USB_UCPD1_2_IRQn
 #endif
 
 uint8_t USBD_GS_CAN_Init(USBD_GS_CAN_HandleTypeDef *hcan, USBD_HandleTypeDef *pdev, led_data_t *leds);

--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -50,7 +50,7 @@ extern USBD_ClassTypeDef USBD_GS_CAN;
 
 struct gs_host_frame_object {
 	struct list_head list;
-	struct gs_host_frame frame;
+	struct GS_HOST_FRAME frame;
 };
 
 typedef struct {
@@ -103,5 +103,5 @@ bool USBD_GS_CAN_CustomDeviceRequest(USBD_HandleTypeDef *pdev, USBD_SetupReqType
 bool USBD_GS_CAN_CustomInterfaceRequest(USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef *req);
 
 bool USBD_GS_CAN_DfuDetachRequested(USBD_HandleTypeDef *pdev);
-uint8_t USBD_GS_CAN_SendFrame(USBD_HandleTypeDef *pdev, struct gs_host_frame *frame);
+uint8_t USBD_GS_CAN_SendFrame(USBD_HandleTypeDef *pdev, struct GS_HOST_FRAME *frame);
 uint8_t USBD_GS_CAN_Transmit(USBD_HandleTypeDef *pdev, uint8_t *buf, uint16_t len);

--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -91,8 +91,8 @@ typedef struct {
 // using (largest packet size / 4) + 1
 # define USB_RX_FIFO_SIZE ((256U / 4U) + 1U)
 #elif defined(STM32G0)
-# define USB_INTERFACE USB_DRD_FS
-# define USB_INTERRUPT USB_UCPD1_2_IRQn
+# define USB_INTERFACE	  USB_DRD_FS
+# define USB_INTERRUPT	  USB_UCPD1_2_IRQn
 #endif
 
 uint8_t USBD_GS_CAN_Init(USBD_GS_CAN_HandleTypeDef *hcan, USBD_HandleTypeDef *pdev, led_data_t *leds);

--- a/src/can.c
+++ b/src/can.c
@@ -149,7 +149,7 @@ bool can_is_rx_pending(can_data_t *hcan)
 	return ((can->RF0R & CAN_RF0R_FMP0) != 0);
 }
 
-bool can_receive(can_data_t *hcan, struct gs_host_frame *rx_frame)
+bool can_receive(can_data_t *hcan, struct GS_HOST_FRAME *rx_frame)
 {
 	CAN_TypeDef *can = hcan->instance;
 
@@ -201,7 +201,7 @@ static CAN_TxMailBox_TypeDef *can_find_free_mailbox(can_data_t *hcan)
 	}
 }
 
-bool can_send(can_data_t *hcan, struct gs_host_frame *frame)
+bool can_send(can_data_t *hcan, struct GS_HOST_FRAME *frame)
 {
 	CAN_TxMailBox_TypeDef *mb = can_find_free_mailbox(hcan);
 	if (mb != 0) {
@@ -260,7 +260,7 @@ static bool status_is_active(uint32_t err)
 	return !(err & (CAN_ESR_BOFF | CAN_ESR_EPVF));
 }
 
-bool can_parse_error_status(uint32_t err, uint32_t last_err, can_data_t *hcan, struct gs_host_frame *frame)
+bool can_parse_error_status(uint32_t err, uint32_t last_err, can_data_t *hcan, struct GS_HOST_FRAME *frame)
 {
 	/* We build up the detailed error information at the same time as we decide
 	 * whether there's anything worth sending. This variable tracks that final

--- a/src/device/can_g0.c
+++ b/src/device/can_g0.c
@@ -1,0 +1,358 @@
+/*
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Hubert Denkmair
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+*/
+
+#include "hal_include.h"
+#include "stm32g0b1xx.h"
+#include <can.h>
+
+void can_init(can_data_t *hcan, FDCAN_GlobalTypeDef *instance)
+{
+	GPIO_InitTypeDef itd;
+
+	// Enable clock
+	RCC_PeriphCLKInitTypeDef PeriphClkInit = {0};
+	PeriphClkInit.PeriphClockSelection = RCC_PERIPHCLK_FDCAN;
+	PeriphClkInit.FdcanClockSelection = RCC_FDCANCLKSOURCE_PCLK1;
+	HAL_RCCEx_PeriphCLKConfig(&PeriphClkInit);
+	__HAL_RCC_FDCAN_CLK_ENABLE(); // TODO: make sure we only do this once ?
+
+	// Setup GPIO
+	// TODO needs to changed for two channel setup
+	if (instance == FDCAN1) {
+		__HAL_RCC_GPIOD_CLK_ENABLE();
+		itd.Pin = GPIO_PIN_0|GPIO_PIN_1;
+		itd.Mode = GPIO_MODE_AF_PP;
+		itd.Pull = GPIO_NOPULL;
+		itd.Speed = GPIO_SPEED_FREQ_LOW;
+		itd.Alternate = GPIO_AF3_FDCAN1;
+		HAL_GPIO_Init(GPIOD, &itd);
+	} else if (instance == FDCAN2) {
+		__HAL_RCC_GPIOC_CLK_ENABLE();
+		itd.Pin = GPIO_PIN_4|GPIO_PIN_5;
+		itd.Mode = GPIO_MODE_AF_PP;
+		itd.Pull = GPIO_NOPULL;
+		itd.Speed = GPIO_SPEED_FREQ_LOW;
+		itd.Alternate = GPIO_AF3_FDCAN1;
+		HAL_GPIO_Init(GPIOC, &itd);
+
+	}
+
+	// setup CAN FD useing the HAL lib
+	hcan->channel.Instance = instance;
+	hcan->channel.Init.ClockDivider = FDCAN_CLOCK_DIV1;
+	hcan->channel.Init.FrameFormat = FDCAN_FRAME_FD_BRS;
+	hcan->channel.Init.Mode = FDCAN_MODE_NORMAL;
+	hcan->channel.Init.AutoRetransmission = DISABLE;
+	hcan->channel.Init.TransmitPause = DISABLE;
+	hcan->channel.Init.ProtocolException = ENABLE;
+	hcan->channel.Init.NominalPrescaler = 8;
+	hcan->channel.Init.NominalSyncJumpWidth = 1;
+	hcan->channel.Init.NominalTimeSeg1 = 13;
+	hcan->channel.Init.NominalTimeSeg2 = 2;
+	hcan->channel.Init.DataPrescaler = 2;
+	hcan->channel.Init.DataSyncJumpWidth = 4;
+	hcan->channel.Init.DataTimeSeg1 = 15;
+	hcan->channel.Init.DataTimeSeg2 = 4;
+	hcan->channel.Init.StdFiltersNbr = 0;
+	hcan->channel.Init.ExtFiltersNbr = 0;
+	hcan->channel.Init.TxFifoQueueMode = FDCAN_TX_FIFO_OPERATION;
+	HAL_FDCAN_Init(&hcan->channel);
+}
+
+bool can_set_bittiming(can_data_t *hcan, uint16_t brp, uint8_t phase_seg1, uint8_t phase_seg2, uint8_t sjw)
+{
+	if (  (brp>0) && (brp<=1024)
+	   && (phase_seg1>0) && (phase_seg1<=16)
+	   && (phase_seg2>0) && (phase_seg2<=8)
+	   && (sjw>0) && (sjw<=4)
+		  ) {
+
+		hcan->channel.Init.NominalSyncJumpWidth = sjw;
+		hcan->channel.Init.NominalTimeSeg1 = phase_seg1;
+		hcan->channel.Init.NominalTimeSeg2 = phase_seg2;
+		hcan->channel.Init.NominalPrescaler = brp;
+		return true;
+	} else {
+		return false;
+	}
+	return 0;
+}
+
+
+bool can_set_data_bittiming(can_data_t *hcan, uint16_t brp, uint8_t phase_seg1, uint8_t phase_seg2, uint8_t sjw)
+{
+	if (  (brp>0) && (brp<=1024)
+	   && (phase_seg1>0) && (phase_seg1<=16)
+	   && (phase_seg2>0) && (phase_seg2<=8)
+	   && (sjw>0) && (sjw<=4)
+		  ) {
+		hcan->channel.Init.DataSyncJumpWidth = sjw;
+		hcan->channel.Init.DataTimeSeg1 = phase_seg1;
+		hcan->channel.Init.DataTimeSeg2 = phase_seg2;
+		hcan->channel.Init.DataPrescaler = brp;
+		return true;
+	} else {
+		return false;
+	}
+}
+
+void can_enable(can_data_t *hcan, bool loop_back, bool listen_only, bool one_shot)
+{
+
+	bool can_mode_fd = false;
+	hcan->channel.Init.AutoRetransmission = one_shot ? DISABLE : ENABLE;
+	if (loop_back && listen_only) hcan->channel.Init.Mode = FDCAN_MODE_INTERNAL_LOOPBACK;
+	else if (loop_back) hcan->channel.Init.Mode = FDCAN_MODE_EXTERNAL_LOOPBACK;
+	else if (listen_only) hcan->channel.Init.Mode = FDCAN_MODE_BUS_MONITORING;
+	else hcan->channel.Init.Mode = FDCAN_MODE_NORMAL;
+	hcan->channel.Init.FrameFormat = can_mode_fd ? FDCAN_FRAME_FD_BRS : FDCAN_FRAME_CLASSIC;
+
+	HAL_FDCAN_Init(&hcan->channel);
+
+	/* Configure reception filter to Rx FIFO 0 on both FDCAN instances */
+	FDCAN_FilterTypeDef sFilterConfig;
+	sFilterConfig.IdType = FDCAN_STANDARD_ID;
+	sFilterConfig.FilterIndex = 0;
+	sFilterConfig.FilterType = FDCAN_FILTER_RANGE;
+	sFilterConfig.FilterConfig = FDCAN_FILTER_DISABLE;
+	sFilterConfig.FilterID1 = 0x000;
+	sFilterConfig.FilterID2 = 0x7FF;
+
+	HAL_FDCAN_ConfigFilter(&hcan->channel, &sFilterConfig);
+
+	/* Configure global filter on both FDCAN instances:
+		 Filter all remote frames with STD and EXT ID
+		 Reject non matching frames with STD ID and EXT ID */
+	HAL_FDCAN_ConfigGlobalFilter(&hcan->channel, FDCAN_ACCEPT_IN_RX_FIFO0, FDCAN_ACCEPT_IN_RX_FIFO0, FDCAN_FILTER_REMOTE, FDCAN_FILTER_REMOTE);
+
+	// Start CAN using HAL
+	HAL_FDCAN_Start(&hcan->channel);
+}
+void can_disable(can_data_t *hcan)
+{
+	HAL_FDCAN_Stop(&hcan->channel);
+}
+
+bool can_is_enabled(can_data_t *hcan)
+{
+	return hcan->channel.State == HAL_FDCAN_STATE_BUSY;
+}
+
+bool can_receive(can_data_t *hcan, struct GS_HOST_FRAME *rx_frame)
+{
+	FDCAN_RxHeaderTypeDef RxHeader;
+
+	if (HAL_FDCAN_GetRxMessage(&hcan->channel, FDCAN_RX_FIFO0, &RxHeader, rx_frame->data) != HAL_OK) {
+		return false;
+	}
+
+	rx_frame->channel = 0;
+	rx_frame->flags = 0;
+
+	rx_frame->can_id = RxHeader.Identifier;
+
+	if (RxHeader.IdType == FDCAN_EXTENDED_ID) {
+		rx_frame->can_id |= CAN_EFF_FLAG;
+	}
+
+	if (RxHeader.RxFrameType == FDCAN_REMOTE_FRAME) {
+		rx_frame->can_id |= CAN_RTR_FLAG;
+	}
+
+	rx_frame->can_dlc = (RxHeader.DataLength & 0x000F0000) >> 16;
+
+	if (RxHeader.FDFormat == FDCAN_FD_CAN) {
+		/* this is a CAN-FD frame */
+		rx_frame->flags = GS_CAN_FLAG_FD;
+		if (RxHeader.BitRateSwitch == FDCAN_BRS_ON) {
+			rx_frame->flags |= GS_CAN_FLAG_BRS;
+		}
+	}
+	return true;
+}
+
+bool can_is_rx_pending(can_data_t *hcan)
+{
+	return (HAL_FDCAN_GetRxFifoFillLevel(&hcan->channel, FDCAN_RX_FIFO0) >= 1);
+}
+
+bool can_send(can_data_t *hcan, struct GS_HOST_FRAME *frame)
+{
+	FDCAN_TxHeaderTypeDef TxHeader;
+
+	TxHeader.DataLength = frame->can_dlc << 16;
+	TxHeader.ErrorStateIndicator = FDCAN_ESI_ACTIVE;
+	TxHeader.TxEventFifoControl = FDCAN_NO_TX_EVENTS;
+	TxHeader.MessageMarker = 0;
+
+	TxHeader.TxFrameType = frame->can_id & CAN_RTR_FLAG ? FDCAN_REMOTE_FRAME : FDCAN_DATA_FRAME;
+
+
+	if (frame->can_id & CAN_EFF_FLAG) {
+		TxHeader.IdType = FDCAN_EXTENDED_ID;
+		TxHeader.Identifier = frame->can_id & 0x1FFFFFFF;
+	}
+	else {
+		TxHeader.IdType = FDCAN_STANDARD_ID;
+		TxHeader.Identifier = frame->can_id & 0x7FF;
+	}
+
+	if (frame->flags & GS_CAN_FLAG_FD) {
+		TxHeader.FDFormat = FDCAN_FD_CAN;
+		if (frame->flags & GS_CAN_FLAG_BRS) {
+			TxHeader.BitRateSwitch = FDCAN_BRS_ON;
+		}
+		else {
+			TxHeader.BitRateSwitch = FDCAN_BRS_OFF;
+		}
+	}
+	else {
+		TxHeader.BitRateSwitch = FDCAN_BRS_OFF;
+		TxHeader.FDFormat = FDCAN_CLASSIC_CAN;
+	}
+
+	if (HAL_FDCAN_AddMessageToTxFifoQ(&hcan->channel, &TxHeader, frame->data) != HAL_OK) {
+		return false;
+	}
+	else {
+		return true;
+	}
+}
+
+uint32_t can_get_error_status(can_data_t *hcan)
+{
+	uint32_t err = hcan->channel.Instance->PSR;
+	/* Write 7 to LEC so we know if it gets set to the same thing again */
+	hcan->channel.Instance->PSR = 7;
+	return err;
+}
+
+static bool status_is_active(uint32_t err)
+{
+#if defined(FDCAN1)
+	return !(err & (FDCAN_PSR_BO | FDCAN_PSR_EP));
+#else
+	return !(err & (CAN_ESR_BOFF | CAN_ESR_EPVF));
+#endif
+
+}
+
+bool can_parse_error_status(uint32_t err, uint32_t last_err, can_data_t *hcan, struct GS_HOST_FRAME *frame)
+{
+	/* We build up the detailed error information at the same time as we decide
+	 * whether there's anything worth sending. This variable tracks that final
+	 * result. */
+	bool should_send = false;
+	(void) hcan;
+
+	frame->echo_id = 0xFFFFFFFF;
+	frame->can_id  = CAN_ERR_FLAG;
+	frame->can_dlc = CAN_ERR_DLC;
+	frame->data[0] = CAN_ERR_LOSTARB_UNSPEC;
+	frame->data[1] = CAN_ERR_CRTL_UNSPEC;
+	frame->data[2] = CAN_ERR_PROT_UNSPEC;
+	frame->data[3] = CAN_ERR_PROT_LOC_UNSPEC;
+	frame->data[4] = CAN_ERR_TRX_UNSPEC;
+	frame->data[5] = 0;
+	frame->data[6] = 0;
+	frame->data[7] = 0;
+
+	/* We transitioned from passive/bus-off to active, so report the edge. */
+	if (!status_is_active(last_err) && status_is_active(err)) {
+		frame->can_id |= CAN_ERR_CRTL;
+		frame->data[1] |= CAN_ERR_CRTL_ACTIVE;
+		should_send = true;
+	}
+
+	if (err & FDCAN_PSR_BO) {
+		if (!(last_err & FDCAN_PSR_BO)) {
+			/* We transitioned to bus-off. */
+			frame->can_id |= CAN_ERR_BUSOFF;
+			should_send = true;
+		}
+	}
+	/* The Linux sja1000 driver puts these counters here. Seems like as good a
+	* place as any. */
+	// TX error count
+	frame->data[6] = ((hcan->channel.Instance->ECR & FDCAN_ECR_TEC) >> FDCAN_ECR_TEC_Pos);
+	// RX error count
+	frame->data[7] = ((hcan->channel.Instance->ECR & FDCAN_ECR_REC) >> FDCAN_ECR_REC_Pos);
+
+	if (err & FDCAN_PSR_EP) {
+		if (!(last_err & FDCAN_PSR_EP)) {
+			frame->can_id |= CAN_ERR_CRTL;
+			frame->data[1] |= CAN_ERR_CRTL_RX_PASSIVE | CAN_ERR_CRTL_TX_PASSIVE;
+			should_send = true;
+		}
+	}
+	else if (err & FDCAN_PSR_EW) {
+		if (!(last_err & FDCAN_PSR_EW)) {
+			frame->can_id |= CAN_ERR_CRTL;
+			frame->data[1] |= CAN_ERR_CRTL_RX_WARNING | CAN_ERR_CRTL_TX_WARNING;
+			should_send = true;
+		}
+	}
+
+	uint8_t lec = err & FDCAN_PSR_LEC;
+	switch (lec) {
+		case 0x01: /* stuff error */
+			frame->can_id |= CAN_ERR_PROT;
+			frame->data[2] |= CAN_ERR_PROT_STUFF;
+			should_send = true;
+			break;
+		case 0x02: /* form error */
+			frame->can_id |= CAN_ERR_PROT;
+			frame->data[2] |= CAN_ERR_PROT_FORM;
+			should_send = true;
+			break;
+		case 0x03: /* ack error */
+			frame->can_id |= CAN_ERR_ACK;
+			should_send = true;
+			break;
+		case 0x04: /* bit recessive error */
+			frame->can_id |= CAN_ERR_PROT;
+			frame->data[2] |= CAN_ERR_PROT_BIT1;
+			should_send = true;
+			break;
+		case 0x05: /* bit dominant error */
+			frame->can_id |= CAN_ERR_PROT;
+			frame->data[2] |= CAN_ERR_PROT_BIT0;
+			should_send = true;
+			break;
+		case 0x06: /* CRC error */
+			frame->can_id |= CAN_ERR_PROT;
+			frame->data[3] |= CAN_ERR_PROT_LOC_CRC_SEQ;
+			should_send = true;
+			break;
+		default: /* 0=no error, 7=no change */
+			break;
+	}
+
+	return should_send;
+}
+
+
+

--- a/src/device/device_g0.c
+++ b/src/device/device_g0.c
@@ -31,12 +31,6 @@ THE SOFTWARE.
 #include "device.h"
 #include "hal_include.h"
 
-void device_can_init(can_data_t *hcan, CAN_TypeDef *instance) {
-	// XXX TODO
-	while (1);
-	return;
-}
-
 void device_sysclock_config(void) {
 	RCC_OscInitTypeDef RCC_OscInitStruct;
 	RCC_ClkInitTypeDef RCC_ClkInitStruct;

--- a/src/main.c
+++ b/src/main.c
@@ -103,7 +103,7 @@ int main(void)
 												struct gs_host_frame_object,
 												list);
 		if (frame_object) { // send CAN message from host
-			struct gs_host_frame *frame = &frame_object->frame;
+			struct GS_HOST_FRAME *frame = &frame_object->frame;
 
 			list_del(&frame_object->list);
 			restore_irq(was_irq_enabled);
@@ -134,13 +134,12 @@ int main(void)
 													struct gs_host_frame_object,
 													list);
 			if (frame_object) {
-				struct gs_host_frame *frame = &frame_object->frame;
+				struct GS_HOST_FRAME *frame = &frame_object->frame;
 
 				list_del(&frame_object->list);
 				restore_irq(was_irq_enabled);
 
 				if (can_receive(channel, frame)) {
-
 					frame->timestamp_us = timer_get();
 					frame->echo_id = 0xFFFFFFFF; // not a echo frame
 					frame->channel = 0;
@@ -168,7 +167,7 @@ int main(void)
 													struct gs_host_frame_object,
 													list);
 			if (frame_object) {
-				struct gs_host_frame *frame = &frame_object->frame;
+				struct GS_HOST_FRAME *frame = &frame_object->frame;
 
 				list_del(&frame_object->list);
 				restore_irq(was_irq_enabled);

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -591,7 +591,7 @@ static uint8_t USBD_GS_CAN_DataOut(USBD_HandleTypeDef *pdev, uint8_t epnum) {
 	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*)pdev->pClassData;
 
 	uint32_t rxlen = USBD_LL_GetRxDataSize(pdev, epnum);
-	if (rxlen < (sizeof(struct gs_host_frame)-4)) {
+	if (rxlen < (sizeof(struct GS_HOST_FRAME)-4)) {
 		// Invalid frame length, just ignore it and receive into the same buffer
 		// again next time.
 		USBD_GS_CAN_PrepareReceive(pdev);
@@ -659,12 +659,12 @@ uint8_t USBD_GS_CAN_Transmit(USBD_HandleTypeDef *pdev, uint8_t *buf, uint16_t le
 	}
 }
 
-uint8_t USBD_GS_CAN_SendFrame(USBD_HandleTypeDef *pdev, struct gs_host_frame *frame)
+uint8_t USBD_GS_CAN_SendFrame(USBD_HandleTypeDef *pdev, struct GS_HOST_FRAME *frame)
 {
 	uint8_t buf[CAN_DATA_MAX_PACKET_SIZE],*send_addr;
 
 	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*)pdev->pClassData;
-	size_t len = sizeof(struct gs_host_frame);
+	size_t len = sizeof(struct GS_HOST_FRAME);
 
 	if (!hcan->timestamps_enabled) {
 		len -= 4;

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -267,7 +267,7 @@ static const struct gs_device_bt_const USBD_GS_CAN_btconst = {
 static inline uint8_t USBD_GS_CAN_PrepareReceive(USBD_HandleTypeDef *pdev)
 {
 	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*)pdev->pClassData;
-	struct gs_host_frame *frame = &hcan->from_host_buf->frame;
+	struct GS_HOST_FRAME *frame = &hcan->from_host_buf->frame;
 
 	return USBD_LL_PrepareReceive(pdev, GSUSB_ENDPOINT_OUT, (uint8_t *)frame, sizeof(*frame));
 }


### PR DESCRIPTION
This is based on @ryedwards  pull request #126  but tries to separate out the CAN relater changes into a separate file.

I am already on holiday so @marckleinebudde will continue to work in this.

This is developed on an NUCLEO-G0B1RE.
And at the moment does not work yet.
TX of CAN frames does not work and it only receives once.

TODO:
  - Fix CAN
  - rebase on multichannel #139 
  - Add some board definitions to support different pinmux configs between boards.