### PR TITLE
Add support for additional F072 boards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,7 @@ endfunction()
 ########## generate list of targets.
 # the "_fw" part is appended automatically
 set(TGTF042_LIST "cantact" "canalyze" "canable" "usb2can" "cannette")
-set(TGTF072_LIST "candleLight" "CANable_MKS" "CONVERTDEVICE_xCAN")
+set(TGTF072_LIST "candleLight" "CANable_MKS" "CONVERTDEVICE_xCAN" "DSD_TECH_SH_C30A" "FYSETC_UCAN")
 set(TGTF407_LIST "STM32F4_DevBoard")
 set(TGTG0B1_LIST "budgetcan")
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ This is firmware for certain STM32F042x/STM32F072xB-based USB-CAN adapters, nota
 - Entreé: https://github.com/tuna-f1sh/entree (STM32F042x6)
 - CANable-MKS: https://github.com/makerbase-mks/CANable-MKS (STM32F072xB)
 - ConvertDevice-xCAN: https://github.com/ConvertDevice/xCAN (STM32F072xB)
+- DSD TECH SH-C30A: https://www.deshide.com/product-details.html?pid=384242&_t=1671089557 (STM32F072xB)
+- FYSETC UCAN: https://www.fysetc.com/products/fysetc-ucan-board-based-on-stm32f072-usb-to-can-adapter-support-with-canable-candlelight-klipper-firmware (STM32F072xB)
 
 Of important note is that the common STM32F103 will NOT work with this firmware because its hardware cannot use both USB and CAN simultaneously.
 Beware also the smaller packages in the F042 series which map a USB and CAN_TX signal on the same pin and are therefore unusable !

--- a/include/config.h
+++ b/include/config.h
@@ -109,6 +109,46 @@ THE SOFTWARE.
 	#define LEDTX_Mode		  GPIO_MODE_OUTPUT_PP
 	#define LEDTX_Active_High 0
 
+#elif defined(BOARD_DSD_TECH_SH_C30A)
+	#define USBD_PRODUCT_STRING_FS	 (uint8_t*) "SH-C30A USB to CAN adapter"
+	#define USBD_MANUFACTURER_STRING (uint8_t*) "DSD TECH"
+	#define DFU_INTERFACE_STRING_FS	 (uint8_t*) "SH-C30A firmware upgrade interface"
+
+	#define CAN_INTERFACE			 CAN
+	#define CAN_CLOCK_SPEED			 48000000
+
+// SILENT pin not connected
+
+	#define LEDRX_GPIO_Port	  GPIOB
+	#define LEDRX_Pin		  GPIO_PIN_1
+	#define LEDRX_Mode		  GPIO_MODE_OUTPUT_PP
+	#define LEDRX_Active_High 0
+
+	#define LEDTX_GPIO_Port	  GPIOB
+	#define LEDTX_Pin		  GPIO_PIN_0
+	#define LEDTX_Mode		  GPIO_MODE_OUTPUT_PP
+	#define LEDTX_Active_High 0
+
+#elif defined(BOARD_FYSETC_UCAN)
+	#define USBD_PRODUCT_STRING_FS	 (uint8_t*) "UCAN USB to CAN adapter"
+	#define USBD_MANUFACTURER_STRING (uint8_t*) "FYSETC"
+	#define DFU_INTERFACE_STRING_FS	 (uint8_t*) "UCAN firmware upgrade interface"
+
+	#define CAN_INTERFACE			 CAN
+	#define CAN_CLOCK_SPEED			 48000000
+
+// SILENT pin not connected
+
+	#define LEDRX_GPIO_Port	  GPIOA
+	#define LEDRX_Pin		  GPIO_PIN_1
+	#define LEDRX_Mode		  GPIO_MODE_OUTPUT_PP
+	#define LEDRX_Active_High 1
+
+	#define LEDTX_GPIO_Port	  GPIOA
+	#define LEDTX_Pin		  GPIO_PIN_0
+	#define LEDTX_Mode		  GPIO_MODE_OUTPUT_PP
+	#define LEDTX_Active_High 1
+
 #elif defined(BOARD_cantact)
 	#define USBD_PRODUCT_STRING_FS	 (uint8_t*) "cantact gs_usb"
 	#define USBD_MANUFACTURER_STRING (uint8_t*) "cantact.io"


### PR DESCRIPTION
- DSD TECH SH-C30A: https://www.deshide.com/product-details.html?pid=384242&_t=1671089557
- FYSETC UCAN: https://www.fysetc.com/products/fysetc-ucan-board-based-on-stm32f072-usb-to-can-adapter-support-with-canable-candlelight-klipper-firmware