### PR TITLE
github action: add markdown link checker

### DIFF
--- a/.github/workflows/md-link.yml
+++ b/.github/workflows/md-link.yml
@@ -1,0 +1,39 @@
+name: "Markdown link check"
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+  push:
+    branches: [ master ]
+    paths:
+      - .github/workflows/markdown-link.yml
+      - '**.md'
+
+  pull_request:
+    branches: [ master ]
+    paths:
+      - .github/workflows/markdown-link.yml
+      - '**.md'
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Create mlc_config.json
+        run: |
+          cat <<EOT >> mlc_config.json
+          {
+            "ignorePatterns": [
+              {
+                "pattern": "www.st.com/SLA0044"
+              }
+            ]
+          }
+          EOT
+
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+        with:
+          config-file: 'mlc_config.json'


### PR DESCRIPTION
Added a [markdown link checker](https://github.com/gaurav-nelson/github-action-markdown-link-check) to detect broken links and avoid issues like #159. See an example run [here](https://github.com/gemesa/candleLight_fw/actions/runs/4773843834/jobs/8487165985). Some links can not be checked (like www.st.com/SLA0044) so I added it to the exclude list. I dont want to add noise to the repo by adding `mlc_config.json` as a separate file so I added it to the `.yml` instead. If you want to schedule the action add it to the `.yml`, I leave it up to you.