### PR TITLE
CI: replace set-output

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,11 @@ jobs:
 
     - name: Get current date
       id: date
-      run: echo "::set-output name=date::$(date +'%Y%m%d')"
+      run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
       
     - name: generate short hash
       id: vars
-      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
     - name: Upload weekly build
       uses: actions/upload-artifact@v3


### PR DESCRIPTION
Fixes #122

Before:

test run:
https://github.com/gemesa/candleLight_fw/actions/runs/4801634233/jobs/8544109203

where test code is:
```
    - name: Get current date
      id: date
      run: echo "::set-output name=date::$(date +'%Y%m%d')"
      
    - name: generate short hash
      id: vars
      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"

    - name: print outputs
      run: |
        echo "${{steps.date.outputs.date}}"
        echo "${{steps.vars.outputs.sha_short}}"
```

After:

test run:
https://github.com/gemesa/candleLight_fw/actions/runs/4801616342/jobs/8544066244

where test code is:
```
    - name: Get current date
      id: date
      run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
      
    - name: generate short hash
      id: vars
      run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT

    - name: print outputs
      run: |
        echo "${{steps.date.outputs.date}}"
        echo "${{steps.vars.outputs.sha_short}}"
```