### PR TITLE
main: provide weak symbols for _close, _lseek, _read, _write

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -53,14 +53,14 @@
 #define ACCESS_ONCE(x) (*(volatile __typeof(x) *)&(x))
 
 #define WRITE_ONCE(x,v) \
-	do { \
-		barrier(); \
-		ACCESS_ONCE(x) = (v); \
-		barrier(); \
-	} while (0)
+		do { \
+			barrier(); \
+			ACCESS_ONCE(x) = (v); \
+			barrier(); \
+		} while (0)
 
 #define READ_ONCE(x) \
-	({ \
+		({ \
 		__typeof(x) __var = ({ \
 			barrier(); \
 			ACCESS_ONCE(x); \
@@ -77,21 +77,21 @@
 #define sizeof_field(_s, _m)	sizeof(((_s *)0)->_m)
 
 #define container_of(ptr, type, member) \
-	({ \
+		({ \
 		__typeof(((type *)0)->member) *_p = (ptr); \
 		(type *)((char *)_p - offsetof(type, member)); \
 	})
 
 #define struct_size(ptr, field, num) \
-	(offsetof(__typeof(*(ptr)), field) + sizeof((ptr)->field[0]) * (num))
+		(offsetof(__typeof(*(ptr)), field) + sizeof((ptr)->field[0]) * (num))
 
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
 
 #define DECLARE_FLEX_ARRAY(_t, _n) \
-	struct { \
-		struct { } __dummy_ ## _n; \
-		_t _n[0]; \
-	}
+		struct { \
+			struct { } __dummy_ ## _n; \
+			_t _n[0]; \
+		}
 
 #define min(x, y)			((x) < (y) ? (x) : (y))
 #define max(x, y)			((x) > (y) ? (x) : (y))

--- a/include/config.h
+++ b/include/config.h
@@ -83,8 +83,6 @@ THE SOFTWARE.
 	#define CAN_CLOCK_SPEED			 48000000
 	#define NUM_CAN_CHANNEL			 1
 
-// SILENT pin not connected
-
 	#define LEDRX_GPIO_Port	  GPIOA
 	#define LEDRX_Pin		  GPIO_PIN_1
 	#define LEDRX_Mode		  GPIO_MODE_OUTPUT_OD
@@ -105,8 +103,6 @@ THE SOFTWARE.
 	#define CAN_INTERFACE			 CAN
 	#define CAN_CLOCK_SPEED			 48000000
 	#define NUM_CAN_CHANNEL			 1
-
-// SILENT pin not connected
 
 	#define LEDRX_GPIO_Port	  GPIOA
 	#define LEDRX_Pin		  GPIO_PIN_0
@@ -155,8 +151,6 @@ THE SOFTWARE.
 	#define CAN_CLOCK_SPEED			 48000000
 	#define NUM_CAN_CHANNEL			 1
 
-// SILENT pin not connected
-
 	#define LEDRX_GPIO_Port	  GPIOB
 	#define LEDRX_Pin		  GPIO_PIN_1
 	#define LEDRX_Mode		  GPIO_MODE_OUTPUT_PP
@@ -177,8 +171,6 @@ THE SOFTWARE.
 	#define CAN_INTERFACE			 CAN
 	#define CAN_CLOCK_SPEED			 48000000
 	#define NUM_CAN_CHANNEL			 1
-
-// SILENT pin not connected
 
 	#define LEDRX_GPIO_Port	  GPIOA
 	#define LEDRX_Pin		  GPIO_PIN_1
@@ -201,8 +193,6 @@ THE SOFTWARE.
 	#define CAN_CLOCK_SPEED			 48000000
 	#define NUM_CAN_CHANNEL			 1
 
-// SILENT pin not connected
-
 	#define LEDRX_GPIO_Port	  GPIOB
 	#define LEDRX_Pin		  GPIO_PIN_0 /* green */
 	#define LEDRX_Mode		  GPIO_MODE_OUTPUT_PP
@@ -223,8 +213,6 @@ THE SOFTWARE.
 	#define CAN_INTERFACE			 CAN
 	#define CAN_CLOCK_SPEED			 48000000
 	#define NUM_CAN_CHANNEL			 1
-
-// SILENT pin not connected
 
 	#define LEDRX_GPIO_Port	  GPIOB
 	#define LEDRX_Pin		  GPIO_PIN_0 /* green */
@@ -247,8 +235,6 @@ THE SOFTWARE.
 	#define CAN_CLOCK_SPEED			 48000000
 	#define NUM_CAN_CHANNEL			 1
 
-// SILENT pin not connected
-
 	#define LEDTX_GPIO_Port	  GPIOA
 	#define LEDTX_Pin		  GPIO_PIN_1 /* blue */
 	#define LEDTX_Mode		  GPIO_MODE_OUTPUT_OD
@@ -270,8 +256,6 @@ THE SOFTWARE.
 	#define CAN_CLOCK_SPEED			 48000000
 	#define NUM_CAN_CHANNEL			 1
 
-// SILENT pin not connected
-
 	#define LEDRX_GPIO_Port	  GPIOB
 	#define LEDRX_Pin		  GPIO_PIN_0 /* green */
 	#define LEDRX_Mode		  GPIO_MODE_OUTPUT_PP
@@ -292,8 +276,6 @@ THE SOFTWARE.
 	#define CAN_INTERFACE			 CAN
 	#define CAN_CLOCK_SPEED			 48000000
 	#define NUM_CAN_CHANNEL			 1
-
-// SILENT pin not connected
 
 	#define LEDRX_GPIO_Port		 GPIOA
 	#define LEDRX_Pin			 GPIO_PIN_9 /* RX: green */

--- a/include/config.h
+++ b/include/config.h
@@ -249,20 +249,10 @@ THE SOFTWARE.
 
 // SILENT pin not connected
 
-	#define LED4_GPIO_Port GPIOA
-	#define LED4_Pin	   GPIO_PIN_0 /* white */
-	#define LED4_Mode	   GPIO_MODE_OUTPUT_OD
-	#define LED4_Active_Low
-
 	#define LEDTX_GPIO_Port	  GPIOA
 	#define LEDTX_Pin		  GPIO_PIN_1 /* blue */
 	#define LEDTX_Mode		  GPIO_MODE_OUTPUT_OD
 	#define LEDTX_Active_High 0
-
-	#define LED3_GPIO_Port	  GPIOA
-	#define LED3_Pin		  GPIO_PIN_2 /* red */
-	#define LED3_Mode		  GPIO_MODE_OUTPUT_OD
-	#define LED3_Active_Low
 
 	#define LEDRX_GPIO_Port	  GPIOB
 	#define LEDRX_Pin		  GPIO_PIN_3 /* green */

--- a/include/config.h
+++ b/include/config.h
@@ -83,15 +83,15 @@ THE SOFTWARE.
 	#define CAN_CLOCK_SPEED			 48000000
 	#define NUM_CAN_CHANNEL			 1
 
-	#define LEDRX_GPIO_Port	  GPIOA
-	#define LEDRX_Pin		  GPIO_PIN_1
-	#define LEDRX_Mode		  GPIO_MODE_OUTPUT_OD
-	#define LEDRX_Active_High 0
+	#define LEDRX_GPIO_Port			 GPIOA
+	#define LEDRX_Pin				 GPIO_PIN_1
+	#define LEDRX_Mode				 GPIO_MODE_OUTPUT_OD
+	#define LEDRX_Active_High		 0
 
-	#define LEDTX_GPIO_Port	  GPIOA
-	#define LEDTX_Pin		  GPIO_PIN_0
-	#define LEDTX_Mode		  GPIO_MODE_OUTPUT_OD
-	#define LEDTX_Active_High 0
+	#define LEDTX_GPIO_Port			 GPIOA
+	#define LEDTX_Pin				 GPIO_PIN_0
+	#define LEDTX_Mode				 GPIO_MODE_OUTPUT_OD
+	#define LEDTX_Active_High		 0
 
 #elif defined(BOARD_CONVERTDEVICE_xCAN)
 	#define USBD_PRODUCT_STRING_FS	 (uint8_t*) "ConvertDevice xCAN"
@@ -104,15 +104,15 @@ THE SOFTWARE.
 	#define CAN_CLOCK_SPEED			 48000000
 	#define NUM_CAN_CHANNEL			 1
 
-	#define LEDRX_GPIO_Port	  GPIOA
-	#define LEDRX_Pin		  GPIO_PIN_0
-	#define LEDRX_Mode		  GPIO_MODE_OUTPUT_PP
-	#define LEDRX_Active_High 0
+	#define LEDRX_GPIO_Port			 GPIOA
+	#define LEDRX_Pin				 GPIO_PIN_0
+	#define LEDRX_Mode				 GPIO_MODE_OUTPUT_PP
+	#define LEDRX_Active_High		 0
 
-	#define LEDTX_GPIO_Port	  GPIOA
-	#define LEDTX_Pin		  GPIO_PIN_1
-	#define LEDTX_Mode		  GPIO_MODE_OUTPUT_PP
-	#define LEDTX_Active_High 0
+	#define LEDTX_GPIO_Port			 GPIOA
+	#define LEDTX_Pin				 GPIO_PIN_1
+	#define LEDTX_Mode				 GPIO_MODE_OUTPUT_PP
+	#define LEDTX_Active_High		 0
 
 #elif defined(BOARD_CONVERTDEVICE_xCANFD)
 	#define USBD_PRODUCT_STRING_FS	 (uint8_t*) "ConvertDevice xCANFD"
@@ -126,19 +126,19 @@ THE SOFTWARE.
 	#define NUM_CAN_CHANNEL			 1
 	#define CONFIG_CANFD			 1
 
-	#define LEDRX_GPIO_Port	  GPIOA
-	#define LEDRX_Pin		  GPIO_PIN_0
-	#define LEDRX_Mode		  GPIO_MODE_OUTPUT_PP
-	#define LEDRX_Active_High 0
+	#define LEDRX_GPIO_Port			 GPIOA
+	#define LEDRX_Pin				 GPIO_PIN_0
+	#define LEDRX_Mode				 GPIO_MODE_OUTPUT_PP
+	#define LEDRX_Active_High		 0
 
-	#define LEDTX_GPIO_Port	  GPIOA
-	#define LEDTX_Pin		  GPIO_PIN_1
-	#define LEDTX_Mode		  GPIO_MODE_OUTPUT_PP
-	#define LEDTX_Active_High 0
+	#define LEDTX_GPIO_Port			 GPIOA
+	#define LEDTX_Pin				 GPIO_PIN_1
+	#define LEDTX_Mode				 GPIO_MODE_OUTPUT_PP
+	#define LEDTX_Active_High		 0
 
-	#define USB_GPIO_Port	  GPIOA
-	#define USB_Pin_DM		  GPIO_PIN_11
-	#define USB_Pin_DP		  GPIO_PIN_12
+	#define USB_GPIO_Port			 GPIOA
+	#define USB_Pin_DM				 GPIO_PIN_11
+	#define USB_Pin_DP				 GPIO_PIN_12
 
 #elif defined(BOARD_DSD_TECH_SH_C30A)
 	#define USBD_PRODUCT_STRING_FS	 (uint8_t*) "SH-C30A USB to CAN adapter"
@@ -151,15 +151,15 @@ THE SOFTWARE.
 	#define CAN_CLOCK_SPEED			 48000000
 	#define NUM_CAN_CHANNEL			 1
 
-	#define LEDRX_GPIO_Port	  GPIOB
-	#define LEDRX_Pin		  GPIO_PIN_1
-	#define LEDRX_Mode		  GPIO_MODE_OUTPUT_PP
-	#define LEDRX_Active_High 0
+	#define LEDRX_GPIO_Port			 GPIOB
+	#define LEDRX_Pin				 GPIO_PIN_1
+	#define LEDRX_Mode				 GPIO_MODE_OUTPUT_PP
+	#define LEDRX_Active_High		 0
 
-	#define LEDTX_GPIO_Port	  GPIOB
-	#define LEDTX_Pin		  GPIO_PIN_0
-	#define LEDTX_Mode		  GPIO_MODE_OUTPUT_PP
-	#define LEDTX_Active_High 0
+	#define LEDTX_GPIO_Port			 GPIOB
+	#define LEDTX_Pin				 GPIO_PIN_0
+	#define LEDTX_Mode				 GPIO_MODE_OUTPUT_PP
+	#define LEDTX_Active_High		 0
 
 #elif defined(BOARD_FYSETC_UCAN)
 	#define USBD_PRODUCT_STRING_FS	 (uint8_t*) "UCAN USB to CAN adapter"
@@ -172,15 +172,15 @@ THE SOFTWARE.
 	#define CAN_CLOCK_SPEED			 48000000
 	#define NUM_CAN_CHANNEL			 1
 
-	#define LEDRX_GPIO_Port	  GPIOA
-	#define LEDRX_Pin		  GPIO_PIN_1
-	#define LEDRX_Mode		  GPIO_MODE_OUTPUT_PP
-	#define LEDRX_Active_High 1
+	#define LEDRX_GPIO_Port			 GPIOA
+	#define LEDRX_Pin				 GPIO_PIN_1
+	#define LEDRX_Mode				 GPIO_MODE_OUTPUT_PP
+	#define LEDRX_Active_High		 1
 
-	#define LEDTX_GPIO_Port	  GPIOA
-	#define LEDTX_Pin		  GPIO_PIN_0
-	#define LEDTX_Mode		  GPIO_MODE_OUTPUT_PP
-	#define LEDTX_Active_High 1
+	#define LEDTX_GPIO_Port			 GPIOA
+	#define LEDTX_Pin				 GPIO_PIN_0
+	#define LEDTX_Mode				 GPIO_MODE_OUTPUT_PP
+	#define LEDTX_Active_High		 1
 
 #elif defined(BOARD_cantact)
 	#define USBD_PRODUCT_STRING_FS	 (uint8_t*) "cantact gs_usb"
@@ -193,15 +193,15 @@ THE SOFTWARE.
 	#define CAN_CLOCK_SPEED			 48000000
 	#define NUM_CAN_CHANNEL			 1
 
-	#define LEDRX_GPIO_Port	  GPIOB
-	#define LEDRX_Pin		  GPIO_PIN_0 /* green */
-	#define LEDRX_Mode		  GPIO_MODE_OUTPUT_PP
-	#define LEDRX_Active_High 1
+	#define LEDRX_GPIO_Port			 GPIOB
+	#define LEDRX_Pin				 GPIO_PIN_0 /* green */
+	#define LEDRX_Mode				 GPIO_MODE_OUTPUT_PP
+	#define LEDRX_Active_High		 1
 
-	#define LEDTX_GPIO_Port	  GPIOB
-	#define LEDTX_Pin		  GPIO_PIN_1 /* red */
-	#define LEDTX_Mode		  GPIO_MODE_OUTPUT_PP
-	#define LEDTX_Active_High 1
+	#define LEDTX_GPIO_Port			 GPIOB
+	#define LEDTX_Pin				 GPIO_PIN_1 /* red */
+	#define LEDTX_Mode				 GPIO_MODE_OUTPUT_PP
+	#define LEDTX_Active_High		 1
 
 #elif defined(BOARD_canable)
 	#define USBD_PRODUCT_STRING_FS	 (uint8_t*) "canable gs_usb"
@@ -214,15 +214,15 @@ THE SOFTWARE.
 	#define CAN_CLOCK_SPEED			 48000000
 	#define NUM_CAN_CHANNEL			 1
 
-	#define LEDRX_GPIO_Port	  GPIOB
-	#define LEDRX_Pin		  GPIO_PIN_0 /* green */
-	#define LEDRX_Mode		  GPIO_MODE_OUTPUT_PP
-	#define LEDRX_Active_High 1
+	#define LEDRX_GPIO_Port			 GPIOB
+	#define LEDRX_Pin				 GPIO_PIN_0 /* green */
+	#define LEDRX_Mode				 GPIO_MODE_OUTPUT_PP
+	#define LEDRX_Active_High		 1
 
-	#define LEDTX_GPIO_Port	  GPIOB
-	#define LEDTX_Pin		  GPIO_PIN_1 /* blue */
-	#define LEDTX_Mode		  GPIO_MODE_OUTPUT_PP
-	#define LEDTX_Active_High 0
+	#define LEDTX_GPIO_Port			 GPIOB
+	#define LEDTX_Pin				 GPIO_PIN_1 /* blue */
+	#define LEDTX_Mode				 GPIO_MODE_OUTPUT_PP
+	#define LEDTX_Active_High		 0
 
 #elif defined(BOARD_usb2can)
 	#define USBD_PRODUCT_STRING_FS	 (uint8_t*) "USB2CAN RCA gs_usb"
@@ -235,15 +235,15 @@ THE SOFTWARE.
 	#define CAN_CLOCK_SPEED			 48000000
 	#define NUM_CAN_CHANNEL			 1
 
-	#define LEDTX_GPIO_Port	  GPIOA
-	#define LEDTX_Pin		  GPIO_PIN_1 /* blue */
-	#define LEDTX_Mode		  GPIO_MODE_OUTPUT_OD
-	#define LEDTX_Active_High 0
+	#define LEDTX_GPIO_Port			 GPIOA
+	#define LEDTX_Pin				 GPIO_PIN_1 /* blue */
+	#define LEDTX_Mode				 GPIO_MODE_OUTPUT_OD
+	#define LEDTX_Active_High		 0
 
-	#define LEDRX_GPIO_Port	  GPIOB
-	#define LEDRX_Pin		  GPIO_PIN_3 /* green */
-	#define LEDRX_Mode		  GPIO_MODE_OUTPUT_OD
-	#define LEDRX_Active_High 0
+	#define LEDRX_GPIO_Port			 GPIOB
+	#define LEDRX_Pin				 GPIO_PIN_3 /* green */
+	#define LEDRX_Mode				 GPIO_MODE_OUTPUT_OD
+	#define LEDRX_Active_High		 0
 
 #elif defined(BOARD_canalyze)
 	#define USBD_PRODUCT_STRING_FS	 (uint8_t*) "CANAlyze gs_usb"
@@ -256,15 +256,15 @@ THE SOFTWARE.
 	#define CAN_CLOCK_SPEED			 48000000
 	#define NUM_CAN_CHANNEL			 1
 
-	#define LEDRX_GPIO_Port	  GPIOB
-	#define LEDRX_Pin		  GPIO_PIN_0 /* green */
-	#define LEDRX_Mode		  GPIO_MODE_OUTPUT_PP
-	#define LEDRX_Active_High 1
+	#define LEDRX_GPIO_Port			 GPIOB
+	#define LEDRX_Pin				 GPIO_PIN_0 /* green */
+	#define LEDRX_Mode				 GPIO_MODE_OUTPUT_PP
+	#define LEDRX_Active_High		 1
 
-	#define LEDTX_GPIO_Port	  GPIOB
-	#define LEDTX_Pin		  GPIO_PIN_1 /* red */
-	#define LEDTX_Mode		  GPIO_MODE_OUTPUT_PP
-	#define LEDTX_Active_High 1
+	#define LEDTX_GPIO_Port			 GPIOB
+	#define LEDTX_Pin				 GPIO_PIN_1 /* red */
+	#define LEDTX_Mode				 GPIO_MODE_OUTPUT_PP
+	#define LEDTX_Active_High		 1
 
 #elif defined(BOARD_cannette)
 	#define USBD_PRODUCT_STRING_FS	 (uint8_t*) "cannette gs_usb"
@@ -277,25 +277,25 @@ THE SOFTWARE.
 	#define CAN_CLOCK_SPEED			 48000000
 	#define NUM_CAN_CHANNEL			 1
 
-	#define LEDRX_GPIO_Port		 GPIOA
-	#define LEDRX_Pin			 GPIO_PIN_9 /* RX: green */
-	#define LEDRX_Mode			 GPIO_MODE_OUTPUT_OD
-	#define LEDRX_Active_High	 0
+	#define LEDRX_GPIO_Port			 GPIOA
+	#define LEDRX_Pin				 GPIO_PIN_9 /* RX: green */
+	#define LEDRX_Mode				 GPIO_MODE_OUTPUT_OD
+	#define LEDRX_Active_High		 0
 
-	#define LEDTX_GPIO_Port		 GPIOA
-	#define LEDTX_Pin			 GPIO_PIN_8 /* TX: red */
-	#define LEDTX_Mode			 GPIO_MODE_OUTPUT_OD
-	#define LEDTX_Active_High	 0
+	#define LEDTX_GPIO_Port			 GPIOA
+	#define LEDTX_Pin				 GPIO_PIN_8 /* TX: red */
+	#define LEDTX_Mode				 GPIO_MODE_OUTPUT_OD
+	#define LEDTX_Active_High		 0
 
-	#define nCANSTBY_Port		 GPIOC
-	#define nCANSTBY_Pin		 GPIO_PIN_14 /* control xceiver standby, active low */
-	#define nCANSTBY_Active_High 1
+	#define nCANSTBY_Port			 GPIOC
+	#define nCANSTBY_Pin			 GPIO_PIN_14 /* control xceiver standby, active low */
+	#define nCANSTBY_Active_High	 1
 
-	#define nSI86EN_Port		 GPIOC
-	#define nSI86EN_Pin			 GPIO_PIN_13 /* enable power to Si86xx isolater, active low */
+	#define nSI86EN_Port			 GPIOC
+	#define nSI86EN_Pin				 GPIO_PIN_13 /* enable power to Si86xx isolater, active low */
 
-	#define DCDCEN_Port			 GPIOC
-	#define DCDCEN_Pin			 GPIO_PIN_15 /* activate DCDC converter, active high */
+	#define DCDCEN_Port				 GPIOC
+	#define DCDCEN_Pin				 GPIO_PIN_15 /* activate DCDC converter, active high */
 
 #elif defined(BOARD_budgetcan)
 	#define USBD_PRODUCT_STRING_FS	 (uint8_t*) "budgetcan gs_usb"
@@ -310,28 +310,28 @@ THE SOFTWARE.
 	#define NUM_CAN_CHANNEL			 2
 	#define CONFIG_CANFD			 1
 
-	#define nCANSTBY_Port		 GPIOA
-	#define nCANSTBY_Pin		 GPIO_PIN_0    /* control xceiver standby, active low */
-	#define nCANSTBY_Active_High 0
+	#define nCANSTBY_Port			 GPIOA
+	#define nCANSTBY_Pin			 GPIO_PIN_0 /* control xceiver standby, active low */
+	#define nCANSTBY_Active_High	 0
 
-	#define LEDRX_GPIO_Port		 GPIOB
-	#define LEDRX_Pin			 GPIO_PIN_4
-	#define LEDRX_Mode			 GPIO_MODE_OUTPUT_PP
-	#define LEDRX_Active_High	 1
+	#define LEDRX_GPIO_Port			 GPIOB
+	#define LEDRX_Pin				 GPIO_PIN_4
+	#define LEDRX_Mode				 GPIO_MODE_OUTPUT_PP
+	#define LEDRX_Active_High		 1
 
-	#define LEDTX_GPIO_Port		 GPIOB
-	#define LEDTX_Pin			 GPIO_PIN_3
-	#define LEDTX_Mode			 GPIO_MODE_OUTPUT_PP
-	#define LEDTX_Active_High	 1
+	#define LEDTX_GPIO_Port			 GPIOB
+	#define LEDTX_Pin				 GPIO_PIN_3
+	#define LEDTX_Mode				 GPIO_MODE_OUTPUT_PP
+	#define LEDTX_Active_High		 1
 
-	#define USB_GPIO_Port		 GPIOA
-	#define USB_Pin_DM			 GPIO_PIN_11
-	#define USB_Pin_DP			 GPIO_PIN_12
+	#define USB_GPIO_Port			 GPIOA
+	#define USB_Pin_DM				 GPIO_PIN_11
+	#define USB_Pin_DP				 GPIO_PIN_12
 
-	#define TERM_GPIO_Port		 GPIOA
-	#define TERM_Pin			 GPIO_PIN_1
-	#define TERM_Mode			 GPIO_MODE_OUTPUT_PP
-	#define TERM_Active_High	 1
+	#define TERM_GPIO_Port			 GPIOA
+	#define TERM_Pin				 GPIO_PIN_1
+	#define TERM_Mode				 GPIO_MODE_OUTPUT_PP
+	#define TERM_Active_High		 1
 
 #elif defined(BOARD_STM32F4_DevBoard)
 	#define USBD_PRODUCT_STRING_FS	 (uint8_t*) "STM32F4VE Dev Board"

--- a/include/config.h
+++ b/include/config.h
@@ -124,7 +124,7 @@ THE SOFTWARE.
 	#define CAN_INTERFACE			 FDCAN1
 	#define CAN_CLOCK_SPEED			 64000000
 	#define NUM_CAN_CHANNEL			 1
-	#define CONFIG_CANFD
+	#define CONFIG_CANFD			 1
 
 	#define LEDRX_GPIO_Port	  GPIOA
 	#define LEDRX_Pin		  GPIO_PIN_0
@@ -308,7 +308,7 @@ THE SOFTWARE.
 	#define CAN_INTERFACE2			 FDCAN2
 	#define CAN_CLOCK_SPEED			 64000000
 	#define NUM_CAN_CHANNEL			 2
-	#define CONFIG_CANFD
+	#define CONFIG_CANFD			 1
 
 	#define nCANSTBY_Port		 GPIOA
 	#define nCANSTBY_Pin		 GPIO_PIN_0    /* control xceiver standby, active low */

--- a/include/list.h
+++ b/include/list.h
@@ -41,7 +41,7 @@
 #define LIST_HEAD_INIT(name) { &(name), &(name) }
 
 #define LIST_HEAD(name) \
-	struct list_head name = LIST_HEAD_INIT(name)
+		struct list_head name = LIST_HEAD_INIT(name)
 
 struct list_head {
 	struct list_head *next;
@@ -129,69 +129,69 @@ list_del_init(struct list_head *entry)
 #define list_entry(ptr, type, field) container_of(ptr, type, field)
 
 #define list_first_entry(ptr, type, member) \
-	list_entry((ptr)->next, type, member)
+		list_entry((ptr)->next, type, member)
 
 #define list_last_entry(ptr, type, member)  \
-	list_entry((ptr)->prev, type, member)
+		list_entry((ptr)->prev, type, member)
 
 #define list_first_entry_or_null(ptr, type, member) \
-	(!list_empty(ptr) ? list_first_entry(ptr, type, member) : NULL)
+		(!list_empty(ptr) ? list_first_entry(ptr, type, member) : NULL)
 
 #define list_next_entry(ptr, member)                    \
-	list_entry(((ptr)->member.next), typeof(*(ptr)), member)
+		list_entry(((ptr)->member.next), typeof(*(ptr)), member)
 
 #define list_safe_reset_next(ptr, n, member) \
-	(n) = list_next_entry(ptr, member)
+		(n) = list_next_entry(ptr, member)
 
 #define list_prev_entry(ptr, member)                    \
-	list_entry(((ptr)->member.prev), typeof(*(ptr)), member)
+		list_entry(((ptr)->member.prev), typeof(*(ptr)), member)
 
 #define list_for_each(p, head)                      \
-	for (p = (head)->next; p != (head); p = (p)->next)
+		for (p = (head)->next; p != (head); p = (p)->next)
 
 #define list_for_each_safe(p, n, head)                  \
-	for (p = (head)->next, n = (p)->next; p != (head); p = n, n = (p)->next)
+		for (p = (head)->next, n = (p)->next; p != (head); p = n, n = (p)->next)
 
 #define list_for_each_entry(p, h, field)                \
-	for (p = list_entry((h)->next, typeof(*p), field); &(p)->field != (h); \
-		 p = list_entry((p)->field.next, typeof(*p), field))
+		for (p = list_entry((h)->next, typeof(*p), field); &(p)->field != (h); \
+			 p = list_entry((p)->field.next, typeof(*p), field))
 
 #define list_for_each_entry_safe(p, n, h, field)            \
-	for (p = list_entry((h)->next, typeof(*p), field),      \
-		 n = list_entry((p)->field.next, typeof(*p), field); &(p)->field != (h); \
-		 p = n, n = list_entry(n->field.next, typeof(*n), field))
+		for (p = list_entry((h)->next, typeof(*p), field),      \
+			 n = list_entry((p)->field.next, typeof(*p), field); &(p)->field != (h); \
+			 p = n, n = list_entry(n->field.next, typeof(*n), field))
 
 #define list_for_each_entry_from(p, h, field) \
-	for ( ; &(p)->field != (h); \
-		  p = list_entry((p)->field.next, typeof(*p), field))
+		for ( ; &(p)->field != (h); \
+			  p = list_entry((p)->field.next, typeof(*p), field))
 
 #define list_for_each_entry_continue(p, h, field)           \
-	for (p = list_next_entry((p), field); &(p)->field != (h);   \
-		 p = list_next_entry((p), field))
+		for (p = list_next_entry((p), field); &(p)->field != (h);   \
+			 p = list_next_entry((p), field))
 
 #define list_for_each_entry_safe_from(pos, n, head, member)         \
-	for (n = list_entry((pos)->member.next, typeof(*pos), member);      \
-		 &(pos)->member != (head);                      \
-		 pos = n, n = list_entry(n->member.next, typeof(*n), member))
+		for (n = list_entry((pos)->member.next, typeof(*pos), member);      \
+			 &(pos)->member != (head);                      \
+			 pos = n, n = list_entry(n->member.next, typeof(*n), member))
 
 #define list_for_each_entry_reverse(p, h, field)            \
-	for (p = list_entry((h)->prev, typeof(*p), field); &(p)->field != (h); \
-		 p = list_entry((p)->field.prev, typeof(*p), field))
+		for (p = list_entry((h)->prev, typeof(*p), field); &(p)->field != (h); \
+			 p = list_entry((p)->field.prev, typeof(*p), field))
 
 #define list_for_each_entry_safe_reverse(p, n, h, field)        \
-	for (p = list_entry((h)->prev, typeof(*p), field),      \
-		 n = list_entry((p)->field.prev, typeof(*p), field); &(p)->field != (h); \
-		 p = n, n = list_entry(n->field.prev, typeof(*n), field))
+		for (p = list_entry((h)->prev, typeof(*p), field),      \
+			 n = list_entry((p)->field.prev, typeof(*p), field); &(p)->field != (h); \
+			 p = n, n = list_entry(n->field.prev, typeof(*n), field))
 
 #define list_for_each_entry_continue_reverse(p, h, field) \
-	for (p = list_entry((p)->field.prev, typeof(*p), field); &(p)->field != (h); \
-		 p = list_entry((p)->field.prev, typeof(*p), field))
+		for (p = list_entry((p)->field.prev, typeof(*p), field); &(p)->field != (h); \
+			 p = list_entry((p)->field.prev, typeof(*p), field))
 
 #define list_for_each_prev(p, h) for (p = (h)->prev; p != (h); p = (p)->prev)
 
 #define list_for_each_entry_from_reverse(p, h, field)   \
-	for (; &p->field != (h);            \
-		 p = list_prev_entry(p, field))
+		for (; &p->field != (h);            \
+			 p = list_prev_entry(p, field))
 
 static inline void
 list_add(struct list_head *new, struct list_head *head)
@@ -303,10 +303,10 @@ struct hlist_node {
 #define HLIST_HEAD(name)	  struct hlist_head name = HLIST_HEAD_INIT
 #define INIT_HLIST_HEAD(head) (head)->first = NULL
 #define INIT_HLIST_NODE(node)                       \
-	do {                                    \
-		(node)->next = NULL;                        \
-		(node)->pprev = NULL;                       \
-	} while (0)
+		do {                                    \
+			(node)->next = NULL;                        \
+			(node)->pprev = NULL;                       \
+		} while (0)
 
 static inline int
 hlist_unhashed(const struct hlist_node *h)
@@ -449,32 +449,32 @@ list_add_tail_locked(struct list_head *entry, struct list_head *head)
 #define hlist_entry(ptr, type, field) container_of(ptr, type, field)
 
 #define hlist_for_each(p, head)                     \
-	for (p = (head)->first; p; p = (p)->next)
+		for (p = (head)->first; p; p = (p)->next)
 
 #define hlist_for_each_safe(p, n, head)                 \
-	for (p = (head)->first; p && ({ n = (p)->next; 1; }); p = n)
+		for (p = (head)->first; p && ({ n = (p)->next; 1; }); p = n)
 
 #define hlist_entry_safe(ptr, type, member) \
-	((ptr) ? hlist_entry(ptr, type, member) : NULL)
+		((ptr) ? hlist_entry(ptr, type, member) : NULL)
 
 #define hlist_for_each_entry(pos, head, member)             \
-	for (pos = hlist_entry_safe((head)->first, typeof(*(pos)), member); \
-		 pos;                           \
-		 pos = hlist_entry_safe((pos)->member.next, typeof(*(pos)), member))
+		for (pos = hlist_entry_safe((head)->first, typeof(*(pos)), member); \
+			 pos;                           \
+			 pos = hlist_entry_safe((pos)->member.next, typeof(*(pos)), member))
 
 #define hlist_for_each_entry_continue(pos, member)          \
-	for (pos = hlist_entry_safe((pos)->member.next, typeof(*(pos)), member); \
-		 (pos);                         \
-		 pos = hlist_entry_safe((pos)->member.next, typeof(*(pos)), member))
+		for (pos = hlist_entry_safe((pos)->member.next, typeof(*(pos)), member); \
+			 (pos);                         \
+			 pos = hlist_entry_safe((pos)->member.next, typeof(*(pos)), member))
 
 #define hlist_for_each_entry_from(pos, member)              \
-	for (; (pos);                               \
-		 pos = hlist_entry_safe((pos)->member.next, typeof(*(pos)), member))
+		for (; (pos);                               \
+			 pos = hlist_entry_safe((pos)->member.next, typeof(*(pos)), member))
 
 #define hlist_for_each_entry_safe(pos, n, head, member)         \
-	for (pos = hlist_entry_safe((head)->first, typeof(*(pos)), member); \
-		 (pos) && ({ n = (pos)->member.next; 1; });         \
-		 pos = hlist_entry_safe(n, typeof(*(pos)), member))
+		for (pos = hlist_entry_safe((head)->first, typeof(*(pos)), member); \
+			 (pos) && ({ n = (pos)->member.next; 1; });         \
+			 pos = hlist_entry_safe(n, typeof(*(pos)), member))
 
 extern void list_sort(void *priv, struct list_head *head, int (*cmp)(void *priv,
 																	 struct list_head *a, struct list_head *b));

--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -40,11 +40,11 @@ THE SOFTWARE.
 /* Define these here so they can be referenced in other files */
 
 #define GS_CAN_EP0_BUF_SIZE \
-	max5(sizeof(struct gs_host_config), \
-		 sizeof(struct gs_device_bittiming), \
-		 sizeof(struct gs_device_mode), \
-		 sizeof(struct gs_identify_mode), \
-		 sizeof(struct gs_device_termination_state))
+		max5(sizeof(struct gs_host_config), \
+			 sizeof(struct gs_device_bittiming), \
+			 sizeof(struct gs_device_mode), \
+			 sizeof(struct gs_identify_mode), \
+			 sizeof(struct gs_device_termination_state))
 #ifdef CONFIG_CANFD
 #define CAN_DATA_MAX_PACKET_SIZE 64    /* Endpoint IN & OUT Packet size */
 #else

--- a/include/util.h
+++ b/include/util.h
@@ -88,9 +88,9 @@ static inline void restore_irq(bool was_enabled)
  *
  */
 #define assert_basic(exp)   \
-	if (exp) {          \
-	} else              \
-	assert_failed()
+		if (exp) {          \
+		} else              \
+		assert_failed()
 
 /** halt / set core to debug state with BKPT.
  *

--- a/include/util_internal.h
+++ b/include/util_internal.h
@@ -23,7 +23,7 @@
  *   ENABLED:   Z_IS_ENABLED2(_XXXX1)
  *   DISABLED   Z_IS_ENABLED2(_XXXX)
  */
-#define Z_IS_ENABLED1(config_macro) Z_IS_ENABLED2(_XXXX##config_macro)
+#define Z_IS_ENABLED1(config_macro) Z_IS_ENABLED2(_XXXX ## config_macro)
 
 /* Here's the core trick, we map "_XXXX1" to "_YYYY," (i.e. a string
  * with a trailing comma), so it has the effect of making this a

--- a/src/main.c
+++ b/src/main.c
@@ -51,6 +51,15 @@ static void SystemClock_Config(void);
 static USBD_GS_CAN_HandleTypeDef hGS_CAN;
 static USBD_HandleTypeDef hUSB = {0};
 
+void __weak _close(void) {
+}
+void __weak _lseek(void) {
+}
+void __weak _read(void) {
+}
+void __weak _write(void) {
+}
+
 int main(void)
 {
 	HAL_Init();

--- a/uncrustify.cfg
+++ b/uncrustify.cfg
@@ -1,4 +1,4 @@
-# Uncrustify-0.75.1
+# Uncrustify-0.78.1_f
 
 #
 # General options
@@ -7,7 +7,7 @@
 # The type of line endings.
 #
 # Default: auto
-newlines                        = lf     # lf/crlf/cr/auto
+newlines                        = lf       # lf/crlf/cr/auto
 
 # The original size of tabs in the input.
 #
@@ -54,6 +54,12 @@ enable_processing_cmt           = " *INDENT-ON*"     # string
 # Enable parsing of digraphs.
 enable_digraphs                 = false    # true/false
 
+# Option to allow both disable_processing_cmt and enable_processing_cmt
+# strings, if specified, to be interpreted as ECMAScript regular expressions.
+# If true, a regex search will be performed within comments according to the
+# specified patterns in order to disable/enable processing.
+processing_cmt_as_regex         = false    # true/false
+
 # Add or remove the UTF-8 BOM (recommend 'remove').
 utf8_bom                        = ignore   # ignore/add/remove/force/not_defined
 
@@ -93,6 +99,17 @@ sp_cpp_lambda_square_paren      = ignore   # ignore/add/remove/force/not_defined
 # no argument list is present, as in '[] <here> { ... }'.
 sp_cpp_lambda_square_brace      = ignore   # ignore/add/remove/force/not_defined
 
+# Add or remove space after the opening parenthesis and before the closing
+# parenthesis of a argument list of a C++11 lambda, as in
+# '[]( <here> ){ ... }'
+# with an empty list.
+sp_cpp_lambda_argument_list_empty = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space after the opening parenthesis and before the closing
+# parenthesis of a argument list of a C++11 lambda, as in
+# '[]( <here> int x <here> ){ ... }'.
+sp_cpp_lambda_argument_list     = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space after the argument list of a C++11 lambda, as in
 # '[](int x) <here> { ... }'.
 sp_cpp_lambda_paren_brace       = ignore   # ignore/add/remove/force/not_defined
@@ -115,6 +132,11 @@ sp_before_assign                = ignore   # ignore/add/remove/force/not_defined
 #
 # Overrides sp_assign.
 sp_after_assign                 = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space in 'enum {'.
+#
+# Default: add
+sp_enum_brace                   = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space in 'NS_ENUM ('.
 sp_enum_paren                   = ignore   # ignore/add/remove/force/not_defined
@@ -179,8 +201,35 @@ sp_before_ptr_star              = ignore   # ignore/add/remove/force/not_defined
 # variable name. If set to ignore, sp_before_ptr_star is used instead.
 sp_before_unnamed_ptr_star      = ignore   # ignore/add/remove/force/not_defined
 
+# Add or remove space before pointer star '*' that is followed by a qualifier.
+# If set to ignore, sp_before_unnamed_ptr_star is used instead.
+sp_before_qualifier_ptr_star    = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space before pointer star '*' that is followed by 'operator' keyword.
+# If set to ignore, sp_before_unnamed_ptr_star is used instead.
+sp_before_operator_ptr_star     = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space before pointer star '*' that is followed by
+# a class scope (as in 'int *MyClass::method()') or namespace scope
+# (as in 'int *my_ns::func()').
+# If set to ignore, sp_before_unnamed_ptr_star is used instead.
+sp_before_scope_ptr_star        = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space before pointer star '*' that is followed by '::',
+# as in 'int *::func()'.
+# If set to ignore, sp_before_unnamed_ptr_star is used instead.
+sp_before_global_scope_ptr_star = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between a qualifier and a pointer star '*' that isn't
+# followed by a variable name, as in '(char const *)'. If set to ignore,
+# sp_before_ptr_star is used instead.
+sp_qualifier_unnamed_ptr_star   = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space between pointer stars '*', as in 'int ***a;'.
 sp_between_ptr_star             = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between pointer star '*' and reference '&', as in 'int *& a;'.
+sp_between_ptr_ref              = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after pointer star '*', if followed by a word.
 #
@@ -199,13 +248,40 @@ sp_after_ptr_star_qualifier     = ignore   # ignore/add/remove/force/not_defined
 # Overrides sp_after_ptr_star and sp_type_func.
 sp_after_ptr_star_func          = ignore   # ignore/add/remove/force/not_defined
 
+# Add or remove space after a pointer star '*' in the trailing return of a
+# function prototype or function definition.
+sp_after_ptr_star_trailing      = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between the pointer star '*' and the name of the variable
+# in a function pointer definition.
+sp_ptr_star_func_var            = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between the pointer star '*' and the name of the type
+# in a function pointer type definition.
+sp_ptr_star_func_type           = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space after a pointer star '*', if followed by an open
 # parenthesis, as in 'void* (*)()'.
 sp_ptr_star_paren               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before a pointer star '*', if followed by a function
-# prototype or function definition.
+# prototype or function definition. If set to ignore, sp_before_ptr_star is
+# used instead.
 sp_before_ptr_star_func         = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between a qualifier and a pointer star '*' followed by
+# the name of the function in a function prototype or definition, as in
+# 'char const *foo()`. If set to ignore, sp_before_ptr_star is used instead.
+sp_qualifier_ptr_star_func      = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space before a pointer star '*' in the trailing return of a
+# function prototype or function definition.
+sp_before_ptr_star_trailing     = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between a qualifier and a pointer star '*' in the
+# trailing return of a function prototype or function definition, as in
+# 'auto foo() -> char const *'.
+sp_qualifier_ptr_star_trailing  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space before a reference sign '&'.
 sp_before_byref                 = ignore   # ignore/add/remove/force/not_defined
@@ -228,6 +304,10 @@ sp_after_byref_func             = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space before a reference sign '&', if followed by a function
 # prototype or function definition.
 sp_before_byref_func            = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space after a reference sign '&', if followed by an open
+# parenthesis, as in 'char& (*)()'.
+sp_byref_paren                  = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between type and word. In cases where total removal of
 # whitespace would be a syntax error, a value of 'remove' is treated the same
@@ -261,6 +341,7 @@ sp_before_angle                 = ignore   # ignore/add/remove/force/not_defined
 sp_inside_angle                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside '<>'.
+# if empty.
 sp_inside_angle_empty           = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between '>' and ':'.
@@ -290,7 +371,7 @@ sp_permit_cpp11_shift           = false    # true/false
 
 # Add or remove space before '(' of control statements ('if', 'for', 'switch',
 # 'while', etc.).
-sp_before_sparen                = add   # ignore/add/remove/force/not_defined
+sp_before_sparen                = add      # ignore/add/remove/force/not_defined
 
 # Add or remove space inside '(' and ')' of control statements other than
 # 'for'.
@@ -305,6 +386,22 @@ sp_inside_sparen_open           = ignore   # ignore/add/remove/force/not_defined
 #
 # Overrides sp_inside_sparen.
 sp_inside_sparen_close          = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space inside '(' and ')' of 'for' statements.
+sp_inside_for                   = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space after '(' of 'for' statements.
+#
+# Overrides sp_inside_for.
+sp_inside_for_open              = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space before ')' of 'for' statements.
+#
+# Overrides sp_inside_for.
+sp_inside_for_close             = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between '((' or '))' of control statements.
+sp_sparen_paren                 = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after ')' of control statements.
 sp_after_sparen                 = ignore   # ignore/add/remove/force/not_defined
@@ -342,6 +439,10 @@ sp_before_semi_for              = ignore   # ignore/add/remove/force/not_defined
 # statement, as in 'for ( <here> ; ; )'.
 sp_before_semi_for_empty        = ignore   # ignore/add/remove/force/not_defined
 
+# Add or remove space between the semicolons of an empty middle part of a for
+# statement, as in 'for ( ; <here> ; )'.
+sp_between_semi_for_empty       = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space after ';', except when followed by a comment.
 #
 # Default: add
@@ -377,6 +478,7 @@ sp_cpp_before_struct_binding    = ignore   # ignore/add/remove/force/not_defined
 sp_inside_square                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside '[]'.
+# if empty.
 sp_inside_square_empty          = ignore   # ignore/add/remove/force/not_defined
 
 # (OC) Add or remove space inside a non-empty Objective-C boxed array '@[' and
@@ -391,15 +493,15 @@ sp_after_comma                  = ignore   # ignore/add/remove/force/not_defined
 # Default: remove
 sp_before_comma                 = remove   # ignore/add/remove/force/not_defined
 
-# (C#) Add or remove space between ',' and ']' in multidimensional array type
+# (C#, Vala) Add or remove space between ',' and ']' in multidimensional array type
 # like 'int[,,]'.
 sp_after_mdatype_commas         = ignore   # ignore/add/remove/force/not_defined
 
-# (C#) Add or remove space between '[' and ',' in multidimensional array type
+# (C#, Vala) Add or remove space between '[' and ',' in multidimensional array type
 # like 'int[,,]'.
 sp_before_mdatype_commas        = ignore   # ignore/add/remove/force/not_defined
 
-# (C#) Add or remove space between ',' in multidimensional array type
+# (C#, Vala) Add or remove space between ',' in multidimensional array type
 # like 'int[,,]'.
 sp_between_mdatype_commas       = ignore   # ignore/add/remove/force/not_defined
 
@@ -409,6 +511,14 @@ sp_between_mdatype_commas       = ignore   # ignore/add/remove/force/not_defined
 # Default: force
 sp_paren_comma                  = force    # ignore/add/remove/force/not_defined
 
+# Add or remove space between a type and ':'.
+sp_type_colon                   = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space after the variadic '...' when preceded by a
+# non-punctuator.
+# The value REMOVE will be overridden with FORCE
+sp_after_ellipsis               = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space before the variadic '...' when preceded by a
 # non-punctuator.
 # The value REMOVE will be overridden with FORCE
@@ -417,8 +527,14 @@ sp_before_ellipsis              = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space between a type and '...'.
 sp_type_ellipsis                = ignore   # ignore/add/remove/force/not_defined
 
+# Add or remove space between a '*' and '...'.
+sp_ptr_type_ellipsis            = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space between ')' and '...'.
 sp_paren_ellipsis               = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between '&&' and '...'.
+sp_byref_ellipsis               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between ')' and a qualifier such as 'const'.
 sp_paren_qualifier              = ignore   # ignore/add/remove/force/not_defined
@@ -478,6 +594,12 @@ sp_sizeof_ellipsis              = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space between 'sizeof...' and '('.
 sp_sizeof_ellipsis_paren        = ignore   # ignore/add/remove/force/not_defined
 
+# Add or remove space between '...' and a parameter pack.
+sp_ellipsis_parameter_pack      = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space between a parameter pack and '...'.
+sp_parameter_pack_ellipsis      = ignore   # ignore/add/remove/force/not_defined
+
 # Add or remove space between 'decltype' and '('.
 sp_decltype_paren               = ignore   # ignore/add/remove/force/not_defined
 
@@ -515,6 +637,7 @@ sp_inside_type_brace_init_lst   = ignore   # ignore/add/remove/force/not_defined
 sp_inside_braces                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside '{}'.
+# if empty.
 sp_inside_braces_empty          = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space around trailing return operator '->'.
@@ -532,7 +655,7 @@ sp_type_brace_init_lst          = ignore   # ignore/add/remove/force/not_defined
 sp_func_proto_paren             = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between function name and '()' on function declaration
-# without parameters.
+# if empty.
 sp_func_proto_paren_empty       = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between function name and '(' with a typedef specifier.
@@ -542,7 +665,7 @@ sp_func_type_paren              = ignore   # ignore/add/remove/force/not_defined
 sp_func_def_paren               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space between function name and '()' on function definition
-# without parameters.
+# if empty.
 sp_func_def_paren_empty         = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside empty function '()'.
@@ -551,6 +674,16 @@ sp_inside_fparens               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside function '(' and ')'.
 sp_inside_fparen                = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space inside user functor '(' and ')'.
+sp_func_call_user_inside_rparen = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space inside empty functor '()'.
+# Overrides sp_after_angle unless use_sp_after_angle_always is set to true.
+sp_inside_rparens               = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space inside functor '(' and ')'.
+sp_inside_rparen                = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space inside the first parentheses in a function type, as in
 # 'void (*x)(...)'.
@@ -602,6 +735,11 @@ sp_func_class_paren             = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space between a constructor without parameters or destructor
 # and '()'.
 sp_func_class_paren_empty       = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space after 'return'.
+#
+# Default: force
+sp_return                       = force    # ignore/add/remove/force/not_defined
 
 # Add or remove space between 'return' and '('.
 sp_return_paren                 = ignore   # ignore/add/remove/force/not_defined
@@ -721,6 +859,10 @@ sp_d_array_colon                = ignore   # ignore/add/remove/force/not_defined
 #
 # Default: remove
 sp_not                          = remove   # ignore/add/remove/force/not_defined
+
+# Add or remove space between two '!' (not) unary operators.
+# If set to ignore, sp_not will be used.
+sp_not_not                      = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove space after the '~' (invert) unary operator.
 #
@@ -882,6 +1024,22 @@ sp_extern_paren                 = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space after the opening of a C++ comment, as in '// <here> A'.
 sp_cmt_cpp_start                = ignore   # ignore/add/remove/force/not_defined
 
+# remove space after the '//' and the pvs command '-V1234',
+# only works with sp_cmt_cpp_start set to add or force.
+sp_cmt_cpp_pvs                  = false    # true/false
+
+# remove space after the '//' and the command 'lint',
+# only works with sp_cmt_cpp_start set to add or force.
+sp_cmt_cpp_lint                 = false    # true/false
+
+# Add or remove space in a C++ region marker comment, as in '// <here> BEGIN'.
+# A region marker is defined as a comment which is not preceded by other text
+# (i.e. the comment is the first non-whitespace on the line), and which starts
+# with either 'BEGIN' or 'END'.
+#
+# Overrides sp_cmt_cpp_start.
+sp_cmt_cpp_region               = ignore   # ignore/add/remove/force/not_defined
+
 # If true, space added with sp_cmt_cpp_start will be added after Doxygen
 # sequences like '///', '///<', '//!' and '//!<'.
 sp_cmt_cpp_doxygen              = false    # true/false
@@ -902,7 +1060,7 @@ sp_between_new_paren            = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space between ')' and type in 'new(foo) BAR'.
 sp_after_newop_paren            = ignore   # ignore/add/remove/force/not_defined
 
-# Add or remove space inside parenthesis of the new operator
+# Add or remove space inside parentheses of the new operator
 # as in 'new(foo) BAR'.
 sp_inside_newop_paren           = ignore   # ignore/add/remove/force/not_defined
 
@@ -918,6 +1076,32 @@ sp_inside_newop_paren_open      = ignore   # ignore/add/remove/force/not_defined
 # Overrides sp_inside_newop_paren.
 sp_inside_newop_paren_close     = ignore   # ignore/add/remove/force/not_defined
 
+# Add or remove space before a trailing comment.
+sp_before_tr_cmt                = ignore   # ignore/add/remove/force/not_defined
+
+# Number of spaces before a trailing comment.
+sp_num_before_tr_cmt            = 0        # unsigned number
+
+# Add or remove space before an embedded comment.
+#
+# Default: force
+sp_before_emb_cmt               = force    # ignore/add/remove/force/not_defined
+
+# Number of spaces before an embedded comment.
+#
+# Default: 1
+sp_num_before_emb_cmt           = 1        # unsigned number
+
+# Add or remove space after an embedded comment.
+#
+# Default: force
+sp_after_emb_cmt                = force    # ignore/add/remove/force/not_defined
+
+# Number of spaces after an embedded comment.
+#
+# Default: 1
+sp_num_after_emb_cmt            = 1        # unsigned number
+
 # (Java) Add or remove space between an annotation and the open parenthesis.
 sp_annotation_paren             = ignore   # ignore/add/remove/force/not_defined
 
@@ -930,6 +1114,12 @@ sp_after_noexcept               = ignore   # ignore/add/remove/force/not_defined
 # Add or remove space after '_'.
 sp_vala_after_translation       = ignore   # ignore/add/remove/force/not_defined
 
+# Add or remove space before a bit colon ':'.
+sp_before_bit_colon             = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove space after a bit colon ':'.
+sp_after_bit_colon              = ignore   # ignore/add/remove/force/not_defined
+
 # If true, a <TAB> is inserted after #define.
 force_tab_after_define          = false    # true/false
 
@@ -941,6 +1131,10 @@ force_tab_after_define          = false    # true/false
 #
 # Default: 8
 indent_columns                  = 4        # unsigned number
+
+# Whether to ignore indent for the first continuation line. Subsequent
+# continuation lines will still be indented to match the first.
+indent_ignore_first_continue    = false    # true/false
 
 # The continuation indent. If non-zero, this overrides the indent of '(', '['
 # and '=' continuation indents. Negative values are OK; negative value is
@@ -1028,11 +1222,24 @@ indent_namespace_level          = 0        # unsigned number
 # indented. Requires indent_namespace=true. 0 means no limit.
 indent_namespace_limit          = 0        # unsigned number
 
+# Whether to indent only in inner namespaces (nested in other namespaces).
+# Requires indent_namespace=true.
+indent_namespace_inner_only     = false    # true/false
+
 # Whether the 'extern "C"' body is indented.
 indent_extern                   = false    # true/false
 
 # Whether the 'class' body is indented.
 indent_class                    = false    # true/false
+
+# Whether to ignore indent for the leading base class colon.
+indent_ignore_before_class_colon = false    # true/false
+
+# Additional indent before the leading base class colon.
+# Negative values decrease indent down to the first column.
+# Requires indent_ignore_before_class_colon=false and a newline break before
+# the colon (see pos_class_colon and nl_class_colon)
+indent_before_class_colon       = 0        # number
 
 # Whether to indent the stuff after a leading base class colon.
 indent_class_colon              = false    # true/false
@@ -1041,6 +1248,9 @@ indent_class_colon              = false    # true/false
 # colon. Requires indent_class_colon=true.
 indent_class_on_colon           = false    # true/false
 
+# Whether to ignore indent for a leading class initializer colon.
+indent_ignore_before_constr_colon = false    # true/false
+
 # Whether to indent the stuff after a leading class initializer colon.
 indent_constr_colon             = false    # true/false
 
@@ -1048,6 +1258,11 @@ indent_constr_colon             = false    # true/false
 #
 # Default: 2
 indent_ctor_init_leading        = 2        # unsigned number
+
+# Virtual indent from the ':' for following member initializers.
+#
+# Default: 2
+indent_ctor_init_following      = 2        # unsigned number
 
 # Additional indent for constructor initializer list.
 # Negative values decrease indent down to the first column.
@@ -1136,6 +1351,12 @@ indent_member                   = 0        # unsigned number
 # The indent_member option will not be effective if this is set to true.
 indent_member_single            = false    # true/false
 
+# Spaces to indent single line ('//') comments on lines before code.
+indent_single_line_comments_before = 0        # unsigned number
+
+# Spaces to indent single line ('//') comments on lines after code.
+indent_single_line_comments_after = 0        # unsigned number
+
 # When opening a paren for a control statement (if, for, while, etc), increase
 # the indent level by this value. Negative values decrease the indent level.
 indent_sparen_extra             = 0        # number
@@ -1146,7 +1367,14 @@ indent_relative_single_line_comments = false    # true/false
 
 # Spaces to indent 'case' from 'switch'. Usually 0 or indent_columns.
 # It might be wise to choose the same value for the option indent_case_brace.
-indent_switch_case              = 4       # unsigned number
+indent_switch_case              = 4        # unsigned number
+
+# Spaces to indent the body of a 'switch' before any 'case'.
+# Usually the same as indent_columns or indent_switch_case.
+indent_switch_body              = 0        # unsigned number
+
+# Whether to ignore indent for '{' following 'case'.
+indent_ignore_case_brace        = false    # true/false
 
 # Spaces to indent '{' from 'case'. By default, the brace will appear under
 # the 'c' in case. Usually set to 0 or indent_columns. Negative values are OK.
@@ -1165,11 +1393,29 @@ indent_switch_pp                = true     # true/false
 # Usually 0.
 indent_case_shift               = 0        # unsigned number
 
+# Whether to align comments before 'case' with the 'case'.
+#
+# Default: true
+indent_case_comment             = true     # true/false
+
+# Whether to indent comments not found in first column.
+#
+# Default: true
+indent_comment                  = true     # true/false
+
 # Whether to indent comments found in first column.
 indent_col1_comment             = false    # true/false
 
 # Whether to indent multi string literal in first column.
 indent_col1_multi_string_literal = false    # true/false
+
+# Align comments on adjacent lines that are this many columns apart or less.
+#
+# Default: 3
+indent_comment_align_thresh     = 3        # unsigned number
+
+# Whether to ignore indent for goto labels.
+indent_ignore_label             = false    # true/false
 
 # How to indent goto labels. Requires indent_ignore_label=false.
 #
@@ -1216,6 +1462,12 @@ indent_paren_after_func_decl    = false    # true/false
 # if the parenthesis is on its own line.
 indent_paren_after_func_call    = false    # true/false
 
+# How to indent a comma when inside braces.
+#  0: Indent by one level (default)
+#  1: Align under the open brace
+# -1: Preserve original indentation
+indent_comma_brace              = 0        # number
+
 # How to indent a comma when inside parentheses.
 #  0: Indent by one level (default)
 #  1: Align under the open parenthesis
@@ -1228,13 +1480,24 @@ indent_comma_paren              = 0        # number
 # -1: Preserve original indentation
 indent_bool_paren               = 1        # number
 
+# Whether to ignore the indentation of a Boolean operator when outside
+# parentheses.
+indent_ignore_bool              = false    # true/false
+
+# Whether to ignore the indentation of an arithmetic operator.
+indent_ignore_arith             = false    # true/false
+
 # Whether to indent a semicolon when inside a for parenthesis.
 # If true, aligns under the open for parenthesis.
 indent_semicolon_for_paren      = false    # true/false
 
+# Whether to ignore the indentation of a semicolon outside of a 'for'
+# statement.
+indent_ignore_semicolon         = false    # true/false
+
 # Whether to align the first expression to following ones
 # if indent_bool_paren=1.
-indent_first_bool_expr          = true    # true/false
+indent_first_bool_expr          = true     # true/false
 
 # Whether to align the first expression to following ones
 # if indent_semicolon_for_paren=true.
@@ -1246,6 +1509,9 @@ indent_square_nl                = false    # true/false
 
 # (ESQL/C) Whether to preserve the relative indent of 'EXEC SQL' bodies.
 indent_preserve_sql             = false    # true/false
+
+# Whether to ignore the indentation of an assignment operator.
+indent_ignore_assign            = false    # true/false
 
 # Whether to align continued statements at the '='. If false or if the '=' is
 # followed by a newline, the next line is indent one tab.
@@ -1342,7 +1608,7 @@ indent_using_block              = true     # true/false
 # How to indent the continuation of ternary operator.
 #
 # 0: Off (default)
-# 1: When the `if_false` is a continuation, indent it under `if_false`
+# 1: When the `if_false` is a continuation, indent it under the `if_true` branch
 # 2: When the `:` is a continuation, indent it under `?`
 indent_ternary_operator         = 0        # unsigned number
 
@@ -1370,9 +1636,14 @@ donot_indent_func_def_close_paren = false    # true/false
 # Newline adding and removing options
 #
 
-# Whether to collapse empty blocks between '{' and '}'.
-# If true, overrides nl_inside_empty_func
+# Whether to collapse empty blocks between '{' and '}' except for functions.
+# Use nl_collapse_empty_body_functions to specify how empty function braces
+# should be formatted.
 nl_collapse_empty_body          = false    # true/false
+
+# Whether to collapse empty blocks between '{' and '}' for functions only.
+# If true, overrides nl_inside_empty_func.
+nl_collapse_empty_body_functions = false    # true/false
 
 # Don't split one-line braced assignments, as in 'foo_t f = { 1, 2 };'.
 nl_assign_leave_one_liners      = false    # true/false
@@ -1401,6 +1672,9 @@ nl_if_leave_one_liners          = false    # true/false
 
 # Don't split one-line while statements, as in 'while(...) b++;'.
 nl_while_leave_one_liners       = false    # true/false
+
+# Don't split one-line do statements, as in 'do { b++; } while(...);'.
+nl_do_leave_one_liners          = false    # true/false
 
 # Don't split one-line for statements, as in 'for(...) b++;'.
 nl_for_leave_one_liners         = false    # true/false
@@ -1823,6 +2097,12 @@ nl_template_end                 = false    # true/false
 # See nl_oc_msg_leave_one_liner.
 nl_oc_msg_args                  = false    # true/false
 
+# (OC) Minimum number of Objective-C message parameters before applying nl_oc_msg_args.
+nl_oc_msg_args_min_params       = 0        # unsigned number
+
+# (OC) Max code width of Objective-C message before applying nl_oc_msg_args.
+nl_oc_msg_args_max_code_width   = 0        # unsigned number
+
 # Add or remove newline between function signature and '{'.
 nl_fdef_brace                   = ignore   # ignore/add/remove/force/not_defined
 
@@ -1835,6 +2115,9 @@ nl_cpp_ldef_brace               = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove newline between 'return' and the return expression.
 nl_return_expr                  = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove newline between 'throw' and the throw expression.
+nl_throw_expr                   = ignore   # ignore/add/remove/force/not_defined
 
 # Whether to add a newline after semicolons, except in 'for' statements.
 nl_after_semicolon              = false    # true/false
@@ -1855,6 +2138,9 @@ nl_type_brace_init_lst_open     = ignore   # ignore/add/remove/force/not_defined
 # Whether to add a newline before the close brace in an unnamed temporary
 # direct-list-initialization.
 nl_type_brace_init_lst_close    = ignore   # ignore/add/remove/force/not_defined
+
+# Whether to add a newline before '{'.
+nl_before_brace_open            = false    # true/false
 
 # Whether to add a newline after '{'.
 nl_after_brace_open             = false    # true/false
@@ -1935,6 +2221,12 @@ nl_before_do                    = ignore   # ignore/add/remove/force/not_defined
 
 # Add or remove blank line after 'do/while' statement.
 nl_after_do                     = ignore   # ignore/add/remove/force/not_defined
+
+# Ignore nl_before_{if,for,switch,do,synchronized} if the control
+# statement is immediately after a case statement.
+# if nl_before_{if,for,switch,do} is set to remove, this option
+# does nothing.
+nl_before_ignore_after_case     = false    # true/false
 
 # Whether to put a blank line before 'return' statements, unless after an open
 # brace.
@@ -2020,7 +2312,7 @@ nl_max_blank_in_func            = 0        # unsigned number
 # The number of newlines inside an empty function body.
 # This option overrides eat_blanks_after_open_brace and
 # eat_blanks_before_close_brace, but is ignored when
-# nl_collapse_empty_body=true
+# nl_collapse_empty_body_functions=true
 nl_inside_empty_func            = 0        # unsigned number
 
 # The number of newlines before a function prototype.
@@ -2058,7 +2350,20 @@ nl_after_func_class_proto_group = 0        # unsigned number
 nl_class_leave_one_liner_groups = false    # true/false
 
 # The number of newlines after '}' of a multi-line function body.
+#
+# Overrides nl_min_after_func_body and nl_max_after_func_body.
 nl_after_func_body              = 0        # unsigned number
+
+# The minimum number of newlines after '}' of a multi-line function body.
+#
+# Only works when nl_after_func_body is 0.
+nl_min_after_func_body          = 0        # unsigned number
+
+# The maximum number of newlines after '}' of a multi-line function body.
+#
+# Only works when nl_after_func_body is 0.
+# Takes precedence over nl_min_after_func_body.
+nl_max_after_func_body          = 0        # unsigned number
 
 # The number of newlines after '}' of a multi-line function body in a class
 # declaration. Also affects class constructors/destructors.
@@ -2071,12 +2376,6 @@ nl_after_func_body_class        = 0        # unsigned number
 #
 # Overrides nl_after_func_body and nl_after_func_body_class.
 nl_after_func_body_one_liner    = 0        # unsigned number
-
-# The number of blank lines after a block of variable definitions at the top
-# of a function body.
-#
-# 0: No change (default).
-nl_func_var_def_blk             = 0        # unsigned number
 
 # The number of newlines before a block of typedefs. If nl_after_access_spec
 # is non-zero, that option takes precedence.
@@ -2094,15 +2393,27 @@ nl_typedef_blk_end              = 0        # unsigned number
 # 0: No change (default).
 nl_typedef_blk_in               = 0        # unsigned number
 
-# The number of empty newlines before a block of variable definitions
+# The minimum number of blank lines after a block of variable definitions
+# at the top of a function body. If any preprocessor directives appear
+# between the opening brace of the function and the variable block, then
+# it is considered as not at the top of the function.Newlines are added
+# before trailing preprocessor directives, if any exist.
+#
+# 0: No change (default).
+nl_var_def_blk_end_func_top     = 0        # unsigned number
+
+# The minimum number of empty newlines before a block of variable definitions
 # not at the top of a function body. If nl_after_access_spec is non-zero,
-# that option takes precedence.
+# that option takes precedence. Newlines are not added at the top of the
+# file or just after an opening brace. Newlines are added above any
+# preprocessor directives before the block.
 #
 # 0: No change (default).
 nl_var_def_blk_start            = 0        # unsigned number
 
-# The number of empty newlines after a block of variable definitions
-# not at the top of a function body.
+# The minimum number of empty newlines after a block of variable definitions
+# not at the top of a function body. Newlines are not added if the block
+# is at the bottom of the file or just before a preprocessor directive.
 #
 # 0: No change (default).
 nl_var_def_blk_end              = 0        # unsigned number
@@ -2130,6 +2441,9 @@ nl_after_multiline_comment      = false    # true/false
 
 # Whether to force a newline after a label's colon.
 nl_after_label_colon            = false    # true/false
+
+# The number of newlines before a struct definition.
+nl_before_struct                = 0        # unsigned number
 
 # The number of newlines after '}' or ';' of a struct/enum/union definition.
 nl_after_struct                 = 0        # unsigned number
@@ -2310,7 +2624,7 @@ ls_code_width                   = false    # true/false
 align_keep_tabs                 = false    # true/false
 
 # Whether to use tabs for aligning.
-align_with_tabs                 = true    # true/false
+align_with_tabs                 = true     # true/false
 
 # Whether to bump out to the next tab when aligning.
 align_on_tabstop                = false    # true/false
@@ -2354,7 +2668,7 @@ align_constr_value_gap          = 0        # unsigned number
 
 # Whether to align parameters in single-line functions that have the same
 # name. The function names must already be aligned with each other.
-align_same_func_call_params     = true    # true/false
+align_same_func_call_params     = true     # true/false
 
 # The span for aligning function-call parameters for single line functions.
 #
@@ -2399,7 +2713,7 @@ align_var_def_thresh            = 0        # number
 align_var_def_gap               = 0        # unsigned number
 
 # Whether to align the colon in struct bit fields.
-align_var_def_colon             = true    # true/false
+align_var_def_colon             = true     # true/false
 
 # The gap for aligning the colon in struct bit fields.
 align_var_def_colon_gap         = 0        # unsigned number
@@ -2425,6 +2739,22 @@ align_assign_func_proto_span    = 0        # unsigned number
 #
 # 0: No limit (default).
 align_assign_thresh             = 0        # number
+
+# Whether to align on the left most assignment when multiple
+# definitions are found on the same line.
+# Depends on 'align_assign_span' and 'align_assign_thresh' settings.
+align_assign_on_multi_var_defs  = false    # true/false
+
+# The span for aligning on '{' in braced init list.
+#
+# 0: Don't align (default).
+align_braced_init_list_span     = 0        # unsigned number
+
+# The threshold for aligning on '{' in braced init list.
+# Use a negative number for absolute thresholds.
+#
+# 0: No limit (default).
+align_braced_init_list_thresh   = 0        # number
 
 # How to apply align_assign_span to function declaration "assignments", i.e.
 # 'virtual void foo() = 0' or '~foo() = {default|delete}'.
@@ -2538,6 +2868,29 @@ align_right_cmt_at_col          = 0        # unsigned number
 # 0: Don't align (default).
 align_func_proto_span           = 0        # unsigned number
 
+# Whether to ignore continuation lines when evaluating the number of
+# new lines for the function prototype alignment's span.
+#
+# false: continuation lines are part of the newlines count
+# true:  continuation lines are not counted
+align_func_proto_span_ignore_cont_lines = false    # true/false
+
+# How to consider (or treat) the '*' in the alignment of function prototypes.
+#
+# 0: Part of the type     'void *   foo();' (default)
+# 1: Part of the function 'void     *foo();'
+# 2: Dangling             'void    *foo();'
+# Dangling: the '*' will not be taken into account when aligning.
+align_func_proto_star_style     = 0        # unsigned number
+
+# How to consider (or treat) the '&' in the alignment of function prototypes.
+#
+# 0: Part of the type     'long &   foo();' (default)
+# 1: Part of the function 'long     &foo();'
+# 2: Dangling             'long    &foo();'
+# Dangling: the '&' will not be taken into account when aligning.
+align_func_proto_amp_style      = 0        # unsigned number
+
 # The threshold for aligning function prototypes.
 # Use a negative number for absolute thresholds.
 #
@@ -2571,9 +2924,22 @@ align_single_line_brace_gap     = 0        # unsigned number
 # 0: Don't align (default).
 align_oc_msg_spec_span          = 0        # unsigned number
 
-# Whether to align macros wrapped with a backslash and a newline. This will
-# not work right if the macro contains a multi-line comment.
-align_nl_cont                   = false    # true/false
+# Whether and how to align backslashes that split a macro onto multiple lines.
+# This will not work right if the macro contains a multi-line comment.
+#
+# 0: Do nothing (default)
+# 1: Align the backslashes in the column at the end of the longest line
+# 2: Align with the backslash that is farthest to the left, or, if that
+#    backslash is farther left than the end of the longest line, at the end of
+#    the longest line
+# 3: Align with the backslash that is farthest to the right
+align_nl_cont                   = 0        # unsigned number
+
+# The minimum number of spaces between the end of a line and its continuation
+# backslash. Requires align_nl_cont.
+#
+# Default: 1
+align_nl_cont_spaces            = 1        # unsigned number
 
 # Whether to align macro functions and variables together.
 align_pp_define_together        = false    # true/false
@@ -2632,6 +2998,41 @@ cmt_width                       = 0        # unsigned number
 # 2: Full reflow (enable cmt_indent_multi for indent with line wrapping due to cmt_width)
 cmt_reflow_mode                 = 0        # unsigned number
 
+# Path to a file that contains regular expressions describing patterns for
+# which the end of one line and the beginning of the next will be folded into
+# the same sentence or paragraph during full comment reflow. The regular
+# expressions are described using ECMAScript syntax. The syntax for this
+# specification is as follows, where "..." indicates the custom regular
+# expression and "n" indicates the nth end_of_prev_line_regex and
+# beg_of_next_line_regex regular expression pair:
+#
+# end_of_prev_line_regex[1] = "...$"
+# beg_of_next_line_regex[1] = "^..."
+# end_of_prev_line_regex[2] = "...$"
+# beg_of_next_line_regex[2] = "^..."
+#             .
+#             .
+#             .
+# end_of_prev_line_regex[n] = "...$"
+# beg_of_next_line_regex[n] = "^..."
+#
+# Note that use of this option overrides the default reflow fold regular
+# expressions, which are internally defined as follows:
+#
+# end_of_prev_line_regex[1] = "[\w,\]\)]$"
+# beg_of_next_line_regex[1] = "^[\w,\[\(]"
+# end_of_prev_line_regex[2] = "\.$"
+# beg_of_next_line_regex[2] = "^[A-Z]"
+cmt_reflow_fold_regex_file      = ""         # string
+
+# Whether to indent wrapped lines to the start of the encompassing paragraph
+# during full comment reflow (cmt_reflow_mode = 2). Overrides the value
+# specified by cmt_sp_after_star_cont.
+#
+# Note that cmt_align_doxygen_javadoc_tags overrides this option for
+# paragraphs associated with javadoc tags
+cmt_reflow_indent_to_paragraph_start = false    # true/false
+
 # Whether to convert all tabs to spaces in comments. If false, tabs in
 # comments are left alone, unless used for indenting.
 cmt_convert_tab_to_spaces       = false    # true/false
@@ -2640,13 +3041,32 @@ cmt_convert_tab_to_spaces       = false    # true/false
 # keyword substitution and leading chars.
 #
 # Default: true
-cmt_indent_multi                = false     # true/false
+cmt_indent_multi                = false    # true/false
+
+# Whether to align doxygen javadoc-style tags ('@param', '@return', etc.)
+# and corresponding fields such that groups of consecutive block tags,
+# parameter names, and descriptions align with one another. Overrides that
+# which is specified by the cmt_sp_after_star_cont. If cmt_width > 0, it may
+# be necessary to enable cmt_indent_multi and set cmt_reflow_mode = 2
+# in order to achieve the desired alignment for line-wrapping.
+cmt_align_doxygen_javadoc_tags  = false    # true/false
+
+# The number of spaces to insert after the star and before doxygen
+# javadoc-style tags (@param, @return, etc). Requires enabling
+# cmt_align_doxygen_javadoc_tags. Overrides that which is specified by the
+# cmt_sp_after_star_cont.
+#
+# Default: 1
+cmt_sp_before_doxygen_javadoc_tags = 1        # unsigned number
+
+# Whether to change trailing, single-line c-comments into cpp-comments.
+cmt_trailing_single_line_c_to_cpp = false    # true/false
 
 # Whether to group c-comments that look like they are in a block.
 cmt_c_group                     = false    # true/false
 
 # Whether to put an empty '/*' on the first line of the combined c-comment.
-cmt_c_nl_start                  = true    # true/false
+cmt_c_nl_start                  = true     # true/false
 
 # Whether to add a newline before the closing '*/' of the combined c-comment.
 cmt_c_nl_end                    = false    # true/false
@@ -2735,7 +3155,7 @@ cmt_insert_before_preproc       = false    # true/false
 # Applies to cmt_insert_func_header.
 #
 # Default: true
-cmt_insert_before_inlines       = false     # true/false
+cmt_insert_before_inlines       = false    # true/false
 
 # Whether a comment should be inserted if the function is a class constructor
 # or destructor.
@@ -2803,8 +3223,11 @@ mod_full_brace_nl               = 0        # unsigned number
 #   mod_full_brace_function
 mod_full_brace_nl_block_rem_mlcond = false    # true/false
 
-# Add or remove unnecessary parenthesis on 'return' statement.
+# Add or remove unnecessary parentheses on 'return' statement.
 mod_paren_on_return             = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove unnecessary parentheses on 'throw' statement.
+mod_paren_on_throw              = ignore   # ignore/add/remove/force/not_defined
 
 # (Pawn) Whether to change optional semicolons to real semicolons.
 mod_pawn_semicolon              = false    # true/false
@@ -2813,8 +3236,25 @@ mod_pawn_semicolon              = false    # true/false
 # statement, as in 'if (a && b > c)' => 'if (a && (b > c))'.
 mod_full_paren_if_bool          = false    # true/false
 
+# Whether to fully parenthesize Boolean expressions after '='
+# statement, as in 'x = a && b > c;' => 'x = (a && (b > c));'.
+mod_full_paren_assign_bool      = false    # true/false
+
+# Whether to fully parenthesize Boolean expressions after '='
+# statement, as in 'return  a && b > c;' => 'return (a && (b > c));'.
+mod_full_paren_return_bool      = false    # true/false
+
 # Whether to remove superfluous semicolons.
 mod_remove_extra_semicolon      = false    # true/false
+
+# Whether to remove duplicate include.
+mod_remove_duplicate_include    = false    # true/false
+
+# the following options (mod_XX_closebrace_comment) use different comment,
+# depending of the setting of the next option.
+# false: Use the c comment (default)
+# true : Use the cpp comment
+mod_add_force_c_closebrace_comment = false    # true/false
 
 # If a function body exceeds the specified number of newlines and doesn't have
 # a comment after the close brace, a comment will be added.
@@ -2877,6 +3317,10 @@ mod_sort_incl_import_grouping_enabled = false    # true/false
 # the close brace, as in 'case X: { ... } break;' => 'case X: { ... break; }'.
 mod_move_case_break             = false    # true/false
 
+# Whether to move a 'return' that appears after a fully braced 'case' before
+# the close brace, as in 'case X: { ... } return;' => 'case X: { ... return; }'.
+mod_move_case_return            = false    # true/false
+
 # Add or remove braces around a fully braced case statement. Will only remove
 # braces if there are no variable declarations in the block.
 mod_case_brace                  = ignore   # ignore/add/remove/force/not_defined
@@ -2887,6 +3331,49 @@ mod_remove_empty_return         = false    # true/false
 
 # Add or remove the comma after the last value of an enumeration.
 mod_enum_last_comma             = ignore   # ignore/add/remove/force/not_defined
+
+# Syntax to use for infinite loops.
+#
+# 0: Leave syntax alone (default)
+# 1: Rewrite as `for(;;)`
+# 2: Rewrite as `while(true)`
+# 3: Rewrite as `do`...`while(true);`
+# 4: Rewrite as `while(1)`
+# 5: Rewrite as `do`...`while(1);`
+#
+# Infinite loops that do not already match one of these syntaxes are ignored.
+# Other options that affect loop formatting will be applied after transforming
+# the syntax.
+mod_infinite_loop               = 0        # unsigned number
+
+# Add or remove the 'int' keyword in 'int short'.
+mod_int_short                   = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove the 'int' keyword in 'short int'.
+mod_short_int                   = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove the 'int' keyword in 'int long'.
+mod_int_long                    = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove the 'int' keyword in 'long int'.
+mod_long_int                    = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove the 'int' keyword in 'int signed'.
+mod_int_signed                  = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove the 'int' keyword in 'signed int'.
+mod_signed_int                  = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove the 'int' keyword in 'int unsigned'.
+mod_int_unsigned                = ignore   # ignore/add/remove/force/not_defined
+
+# Add or remove the 'int' keyword in 'unsigned int'.
+mod_unsigned_int                = ignore   # ignore/add/remove/force/not_defined
+
+# If there is a situation where mod_int_* and mod_*_int would result in
+# multiple int keywords, whether to keep the rightmost int (the default) or the
+# leftmost int.
+mod_int_prefer_int_on_left      = false    # true/false
 
 # (OC) Whether to organize the properties. If true, properties will be
 # rearranged according to the mod_sort_oc_property_*_weight factors.
@@ -2919,6 +3406,16 @@ mod_sort_oc_property_nullability_weight = 0        # number
 # Preprocessor options
 #
 
+# How to use tabs when indenting preprocessor code.
+#
+# -1: Use 'indent_with_tabs' setting (default)
+#  0: Spaces only
+#  1: Indent with tabs to brace level, align with spaces
+#  2: Indent and align with tabs, using spaces when not on a tabstop
+#
+# Default: -1
+pp_indent_with_tabs             = -1       # number
+
 # Add or remove indentation of preprocessor directives inside #if blocks
 # at brace level 0 (file-level).
 pp_indent                       = ignore   # ignore/add/remove/force/not_defined
@@ -2926,6 +3423,10 @@ pp_indent                       = ignore   # ignore/add/remove/force/not_defined
 # Whether to indent #if/#else/#endif at the brace level. If false, these are
 # indented from column 1.
 pp_indent_at_level              = false    # true/false
+
+# Whether to indent #if/#else/#endif at the parenthesis level if the brace
+# level is 0. If false, these are indented from column 1.
+pp_indent_at_level0             = false    # true/false
 
 # Specifies the number of columns to indent preprocessors per level
 # at brace level 0 (file-level). If pp_indent_at_level=false, also specifies
@@ -2935,10 +3436,10 @@ pp_indent_at_level              = false    # true/false
 # Default: 1
 pp_indent_count                 = 1        # unsigned number
 
-# Add or remove space after # based on pp_level of #if blocks.
-pp_space                        = ignore   # ignore/add/remove/force/not_defined
+# Add or remove space after # based on pp level of #if blocks.
+pp_space_after                  = ignore   # ignore/add/remove/force/not_defined
 
-# Sets the number of spaces per level added with pp_space.
+# Sets the number of spaces per level added with pp_space_after.
 pp_space_count                  = 0        # unsigned number
 
 # The indent for '#region' and '#endregion' in C# and '#pragma region' in
@@ -2958,29 +3459,47 @@ pp_indent_if                    = 0        # number
 # Whether to indent the code between #if, #else and #endif.
 pp_if_indent_code               = false    # true/false
 
+# Whether to indent the body of an #if that encompasses all the code in the file.
+pp_indent_in_guard              = false    # true/false
+
 # Whether to indent '#define' at the brace level. If false, these are
 # indented from column 1.
 pp_define_at_level              = false    # true/false
 
+# Whether to indent '#include' at the brace level.
+pp_include_at_level             = false    # true/false
+
 # Whether to ignore the '#define' body while formatting.
 pp_ignore_define_body           = false    # true/false
 
+# An offset value that controls the indentation of the body of a multiline #define.
+# 'body' refers to all the lines of a multiline #define except the first line.
+# Requires 'pp_ignore_define_body = false'.
+#
+#  <0: Absolute column: the body indentation starts off at the specified column
+#      (ex. -3 ==> the body is indented starting from column 3)
+# >=0: Relative to the column of the '#' of '#define'
+#      (ex.  3 ==> the body is indented starting 3 columns at the right of '#')
+#
+# Default: 8
+pp_multiline_define_body_indent = 8        # number
+
 # Whether to indent case statements between #if, #else, and #endif.
-# Only applies to the indent of the preprocesser that the case statements
+# Only applies to the indent of the preprocessor that the case statements
 # directly inside of.
 #
 # Default: true
 pp_indent_case                  = true     # true/false
 
 # Whether to indent whole function definitions between #if, #else, and #endif.
-# Only applies to the indent of the preprocesser that the function definition
+# Only applies to the indent of the preprocessor that the function definition
 # is directly inside of.
 #
 # Default: true
 pp_indent_func_def              = true     # true/false
 
 # Whether to indent extern C blocks between #if, #else, and #endif.
-# Only applies to the indent of the preprocesser that the extern block is
+# Only applies to the indent of the preprocessor that the extern block is
 # directly inside of.
 #
 # Default: true
@@ -2988,13 +3507,35 @@ pp_indent_extern                = true     # true/false
 
 # How to indent braces directly inside #if, #else, and #endif.
 # Requires pp_if_indent_code=true and only applies to the indent of the
-# preprocesser that the braces are directly inside of.
+# preprocessor that the braces are directly inside of.
 #  0: No extra indent
 #  1: Indent by one level
 # -1: Preserve original indentation
 #
 # Default: 1
 pp_indent_brace                 = 1        # number
+
+# Whether to print warning messages for unbalanced #if and #else blocks.
+# This will print a message in the following cases:
+# - if an #ifdef block ends on a different indent level than
+#   where it started from. Example:
+#
+#    #ifdef TEST
+#      int i;
+#      {
+#        int j;
+#    #endif
+#
+# - an #elif/#else block ends on a different indent level than
+#   the corresponding #ifdef block. Example:
+#
+#    #ifdef TEST
+#        int i;
+#    #else
+#        }
+#      int j;
+#    #endif
+pp_warn_unbalanced_if           = false    # true/false
 
 #
 # Sort includes options
@@ -3039,10 +3580,10 @@ use_indent_continue_only_once   = false    # true/false
 
 # The indentation can be:
 # - after the assignment, at the '[' character
-# - at the begin of the lambda body
+# - at the beginning of the lambda body
 #
-# true:  indentation will be after the assignment
-# false: indentation will be at the begin of the lambda body (default)
+# true:  indentation will be at the beginning of the lambda body
+# false: indentation will be after the assignment (default)
 indent_cpp_lambda_only_once     = false    # true/false
 
 # Whether sp_after_angle takes precedence over sp_inside_fparen. This was the
@@ -3090,6 +3631,26 @@ debug_line_number_to_protocol   = 0        # number
 # only for linux
 debug_timeout                   = 0        # number
 
+# Set the number of characters to be printed if the text is too long,
+# 0: do not truncate.
+debug_truncate                  = 0        # unsigned number
+
+# sort (or not) the tracking info.
+#
+# Default: true
+debug_sort_the_tracks           = true     # true/false
+
+# decode (or not) the flags as a new line.
+# only if the -p option is set.
+debug_decode_the_flags          = false    # true/false
+
+# use (or not) the exit(EX_SOFTWARE) function.
+#
+# Default: true
+debug_use_the_exit_function_pop = true     # true/false
+
+# insert the number of the line at the beginning of each line
+set_numbering_for_html_output   = false    # true/false
 
 # Meaning of the settings:
 #   Ignore - do not do any changes
@@ -3143,5 +3704,5 @@ debug_timeout                   = 0        # number
 #       `macro-close END_MESSAGE_MAP`
 #
 #
-# option(s) with 'not default' value: 0
+# option(s) with 'not default' value: 18
 #


### PR DESCRIPTION
This increases the size of the binary in a stm32f072 a bit:

before:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       17296 B       128 KB     13.20%
             RAM:        4268 B        16 KB     26.05%
```

after:
```
Memory region         Used Size  Region Size  %age Used
           FLASH:       17312 B       128 KB     13.21%
             RAM:        4268 B        16 KB     26.05%
```

Closes: https://github.com/candle-usb/candleLight_fw/issues/164