### PR TITLE
make feature a per channel property

### DIFF
--- a/include/can.h
+++ b/include/can.h
@@ -41,6 +41,7 @@ typedef struct {
 #endif
 	struct list_head list_from_host;
 	led_data_t leds;
+	uint32_t feature;
 	uint32_t reg_esr_old;
 #if defined (CONFIG_BXCAN)
 	struct gs_device_filter filter;

--- a/include/can.h
+++ b/include/can.h
@@ -1,28 +1,27 @@
 /*
-
-The MIT License (MIT)
-
-Copyright (c) 2016 Hubert Denkmair
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-*/
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Hubert Denkmair
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
 
 #pragma once
 

--- a/include/can.h
+++ b/include/can.h
@@ -40,6 +40,7 @@ typedef struct {
 #endif
 	struct list_head list_from_host;
 	led_data_t leds;
+	uint32_t feature;
 	uint32_t reg_esr_old;
 #if defined (CONFIG_BXCAN)
 	struct gs_device_filter filter;
@@ -82,7 +83,7 @@ static inline void can_set_filter(can_data_t *channel, const struct gs_device_fi
 }
 #endif
 
-void can_enable(can_data_t *channel, uint32_t mode);
+void can_enable(can_data_t *channel);
 void can_disable(can_data_t *channel);
 bool can_is_enabled(can_data_t *channel);
 

--- a/include/host_frame.h
+++ b/include/host_frame.h
@@ -1,0 +1,62 @@
+/*
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Marc Kleine-Budde <kernel@pengutronix.de>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include "can.h"
+#include "compiler.h"
+#include "usbd_gs_can.h"
+
+#if NUM_CAN_CHANNEL == 1
+
+static inline can_data_t
+*gs_host_frame_object_get_channel(USBD_GS_CAN_HandleTypeDef *hcan,
+								  struct gs_host_frame_object __maybe_unused *frame_object)
+{
+	return hcan->channels;
+}
+
+static inline void
+gs_host_frame_object_set_channel(struct gs_host_frame_object __maybe_unused *frame_object,
+								 can_data_t __maybe_unused *channel)
+{
+}
+
+#else
+
+static inline can_data_t
+*gs_host_frame_object_get_channel(USBD_GS_CAN_HandleTypeDef __maybe_unused *hcan,
+								  struct gs_host_frame_object *frame_object)
+{
+	return frame_object->channel;
+}
+
+static inline void
+gs_host_frame_object_set_channel(struct gs_host_frame_object *frame_object,
+								 can_data_t *channel)
+{
+	frame_object->channel = channel;
+}
+
+#endif

--- a/include/host_frame.h
+++ b/include/host_frame.h
@@ -1,0 +1,42 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Marc Kleine-Budde <kernel@pengutronix.de>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include "can.h"
+#include "config.h"
+#include "usbd_gs_can.h"
+
+static inline can_data_t
+*gs_host_frame_object_get_channel(USBD_GS_CAN_HandleTypeDef *hcan,
+								  struct gs_host_frame_object *frame_object)
+{
+	u8 channel_nr = 0;
+
+	if (NUM_CAN_CHANNEL > 1)
+		channel_nr = frame_object->frame.channel;
+
+	return &hcan->channels[channel_nr];
+}

--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -73,6 +73,9 @@ struct gs_host_frame_object {
 		uint8_t _buf[GS_HOST_FRAME_SIZE];
 		struct gs_host_frame frame;
 	};
+#if NUM_CAN_CHANNEL > 1
+	can_data_t *channel;
+#endif
 };
 
 typedef struct {
@@ -104,7 +107,6 @@ typedef struct {
 
 	can_data_t channels[NUM_CAN_CHANNEL];
 
-	uint32_t feature;
 	uint32_t sof_timestamp_us;
 
 	struct gs_host_frame_object msgbuf[CAN_QUEUE_SIZE];

--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -33,7 +33,6 @@
 #include "config.h"
 #include "dfu.h"
 #include "gs_usb.h"
-#include "led.h"
 #include "list.h"
 #include "usbd_def.h"
 

--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -1,28 +1,27 @@
 /*
-
-The MIT License (MIT)
-
-Copyright (c) 2016 Hubert Denkmair
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-*/
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Hubert Denkmair
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
 
 #pragma once
 

--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -102,7 +102,6 @@ typedef struct {
 
 	can_data_t channels[NUM_CAN_CHANNEL];
 
-	uint32_t feature;
 	uint32_t sof_timestamp_us;
 
 	struct gs_host_frame_object msgbuf[CAN_QUEUE_SIZE];

--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -150,6 +150,8 @@ void can_enable(can_data_t *channel, uint32_t feature)
 {
 	CAN_TypeDef *can = channel->instance;
 
+	channel->feature = feature;
+
 	uint32_t mcr = CAN_MCR_INRQ
 				   | CAN_MCR_ABOM
 				   | CAN_MCR_TXFP;

--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -146,8 +146,9 @@ static bool can_apply_filter(const can_data_t *channel)
 	return true;
 }
 
-void can_enable(can_data_t *channel, uint32_t feature)
+void can_enable(can_data_t *channel)
 {
+	const uint32_t feature = channel->feature;
 	CAN_TypeDef *can = channel->instance;
 
 	uint32_t mcr = CAN_MCR_INRQ | CAN_MCR_ABOM | CAN_MCR_TXFP;

--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -150,9 +150,7 @@ void can_enable(can_data_t *channel, uint32_t feature)
 {
 	CAN_TypeDef *can = channel->instance;
 
-	uint32_t mcr = CAN_MCR_INRQ
-				   | CAN_MCR_ABOM
-				   | CAN_MCR_TXFP;
+	uint32_t mcr = CAN_MCR_INRQ | CAN_MCR_ABOM | CAN_MCR_TXFP;
 
 	if (feature & GS_CAN_FEATURE_ONE_SHOT) {
 		mcr |= CAN_MCR_NART;
@@ -170,8 +168,8 @@ void can_enable(can_data_t *channel, uint32_t feature)
 
 	// Reset CAN peripheral
 	can->MCR |= CAN_MCR_RESET;
-	while ((can->MCR & CAN_MCR_RESET) != 0);                                                 // reset bit is set to zero after reset
-	while ((can->MSR & CAN_MSR_SLAK) == 0);                                                // should be in sleep mode after reset
+	while ((can->MCR & CAN_MCR_RESET) != 0);        // reset bit is set to zero after reset
+	while ((can->MSR & CAN_MSR_SLAK) == 0);         // should be in sleep mode after reset
 
 	// Completely reset while being of the bus
 	rcc_reset(can);
@@ -201,12 +199,14 @@ void can_disable(can_data_t *channel)
 bool can_is_enabled(can_data_t *channel)
 {
 	CAN_TypeDef *can = channel->instance;
+
 	return (can->MCR & CAN_MCR_INRQ) == 0;
 }
 
 bool can_is_rx_pending(can_data_t *channel)
 {
 	CAN_TypeDef *can = channel->instance;
+
 	return ((can->RF0R & CAN_RF0R_FMP0) != 0);
 }
 
@@ -253,13 +253,13 @@ bool can_receive(can_data_t *channel, struct gs_host_frame *rx_frame)
 static CAN_TxMailBox_TypeDef *can_find_free_mailbox(can_data_t *channel)
 {
 	CAN_TypeDef *can = channel->instance;
-
 	uint32_t tsr = can->TSR;
-	if ( tsr & CAN_TSR_TME0 ) {
+
+	if (tsr & CAN_TSR_TME0) {
 		return &can->sTxMailBox[0];
-	} else if ( tsr & CAN_TSR_TME1 ) {
+	} else if (tsr & CAN_TSR_TME1) {
 		return &can->sTxMailBox[1];
-	} else if ( tsr & CAN_TSR_TME2 ) {
+	} else if (tsr & CAN_TSR_TME2) {
 		return &can->sTxMailBox[2];
 	} else {
 		return 0;
@@ -269,8 +269,8 @@ static CAN_TxMailBox_TypeDef *can_find_free_mailbox(can_data_t *channel)
 bool can_send(can_data_t *channel, struct gs_host_frame *frame)
 {
 	CAN_TxMailBox_TypeDef *mb = can_find_free_mailbox(channel);
-	if (mb != 0) {
 
+	if (mb != 0) {
 		/* first, clear transmission request */
 		mb->TIR &= CAN_TI0R_TXRQ;
 
@@ -287,17 +287,11 @@ bool can_send(can_data_t *channel, struct gs_host_frame *frame)
 		mb->TDTR &= 0xFFFFFFF0;
 		mb->TDTR |= frame->can_dlc & 0x0F;
 
-		mb->TDLR =
-			( frame->classic_can->data[3] << 24 )
-			| ( frame->classic_can->data[2] << 16 )
-			| ( frame->classic_can->data[1] <<  8 )
-			| ( frame->classic_can->data[0] <<  0 );
+		mb->TDLR = (frame->classic_can->data[3] << 24) | (frame->classic_can->data[2] << 16) |
+				   (frame->classic_can->data[1] << 8) | (frame->classic_can->data[0] << 0);
 
-		mb->TDHR =
-			( frame->classic_can->data[7] << 24 )
-			| ( frame->classic_can->data[6] << 16 )
-			| ( frame->classic_can->data[5] <<  8 )
-			| ( frame->classic_can->data[4] <<  0 );
+		mb->TDHR = (frame->classic_can->data[7] << 24) | (frame->classic_can->data[6] << 16) |
+				   (frame->classic_can->data[5] << 8) | (frame->classic_can->data[4] << 0);
 
 		/* request transmission */
 		mb->TIR |= CAN_TI0R_TXRQ;
@@ -317,11 +311,10 @@ bool can_send(can_data_t *channel, struct gs_host_frame *frame)
 uint32_t can_get_error_status(can_data_t *channel)
 {
 	CAN_TypeDef *can = channel->instance;
-
 	uint32_t err = can->ESR;
 
 	/* Write 7 to LEC so we know if it gets set to the same thing again */
-	can->ESR = 7<<4;
+	can->ESR = 7 << 4;
 
 	return err;
 }
@@ -334,9 +327,11 @@ static bool status_is_active(uint32_t err)
 bool can_parse_error_status(can_data_t *channel, struct gs_host_frame *frame, uint32_t err)
 {
 	uint32_t last_err = channel->reg_esr_old;
-	/* We build up the detailed error information at the same time as we decide
+	/*
+	 * We build up the detailed error information at the same time as we decide
 	 * whether there's anything worth sending. This variable tracks that final
-	 * result. */
+	 * result.
+	 */
 	bool should_send = false;
 
 	channel->reg_esr_old = err;
@@ -375,10 +370,12 @@ bool can_parse_error_status(can_data_t *channel, struct gs_host_frame *frame, ui
 		should_send = true;
 	}
 
-	uint8_t tx_error_cnt = (err>>16) & 0xFF;
-	uint8_t rx_error_cnt = (err>>24) & 0xFF;
-	/* The Linux sja1000 driver puts these counters here. Seems like as good a
-	 * place as any. */
+	uint8_t tx_error_cnt = (err >> 16) & 0xFF;
+	uint8_t rx_error_cnt = (err >> 24) & 0xFF;
+	/*
+	 * The Linux sja1000 driver puts these counters here. Seems like as good a
+	 * place as any.
+	 */
 	frame->classic_can->data[6] = tx_error_cnt;
 	frame->classic_can->data[7] = rx_error_cnt;
 

--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -1,27 +1,26 @@
 /*
-
-   The MIT License (MIT)
-
-   Copyright (c) 2016 Hubert Denkmair
-
-   Permission is hereby granted, free of charge, to any person obtaining a copy
-   of this software and associated documentation files (the "Software"), to deal
-   in the Software without restriction, including without limitation the rights
-   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-   copies of the Software, and to permit persons to whom the Software is
-   furnished to do so, subject to the following conditions:
-
-   The above copyright notice and this permission notice shall be included in
-   all copies or substantial portions of the Software.
-
-   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-   THE SOFTWARE.
-
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Hubert Denkmair
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
  */
 
 #include "board.h"

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -25,6 +25,7 @@ THE SOFTWARE.
 */
 
 #include "can_common.h"
+#include "host_frame.h"
 #include "led.h"
 #include "timer.h"
 #include "usbd_gs_can.h"
@@ -125,6 +126,7 @@ void CAN_ReceiveFrame(USBD_GS_CAN_HandleTypeDef *hcan, can_data_t *channel)
 
 	frame->echo_id = 0xFFFFFFFF; // not an echo frame
 	frame->reserved = 0;
+	gs_host_frame_object_set_channel(frame_object, channel);
 
 	list_add_tail_locked(&frame_object->list, &hcan->list_to_host);
 

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -34,6 +34,7 @@ THE SOFTWARE.
 #include "dfu.h"
 #include "gpio.h"
 #include "gs_usb.h"
+#include "host_frame.h"
 #include "led.h"
 #include "timer.h"
 #include "usbd_core.h"
@@ -561,8 +562,6 @@ static uint8_t USBD_GS_CAN_EP0_RxReady(USBD_HandleTypeDef *pdev) {
 				can_disable(channel);
 				led_set_mode(&channel->leds, LED_MODE_OFF);
 			} else if (mode->mode == GS_CAN_MODE_START) {
-				hcan->feature = mode->feature;
-
 				can_enable(channel, mode->feature);
 
 				led_set_mode(&channel->leds, LED_MODE_NORMAL);
@@ -675,6 +674,8 @@ static uint8_t USBD_GS_CAN_DataOut(USBD_HandleTypeDef *pdev, uint8_t epnum) {
 	if (!channel) {
 		goto out_prepare_receive;
 	}
+
+	gs_host_frame_object_set_channel(hcan->from_host_buf[0], channel);
 
 	if (IS_ENABLED(CONFIG_CANFD) &&
 		hcan->from_host_buf[0]->frame.flags & GS_CAN_FLAG_FD &&
@@ -843,22 +844,25 @@ static uint8_t USBD_GS_CAN_Transmit(USBD_HandleTypeDef *pdev, uint8_t *buf, uint
 	}
 }
 
-static uint8_t USBD_GS_CAN_SendFrame(USBD_HandleTypeDef *pdev, struct gs_host_frame *frame)
+static uint8_t USBD_GS_CAN_SendFrame(USBD_HandleTypeDef *pdev,
+									 struct gs_host_frame_object *frame_object)
 {
 	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*)pdev->pClassData;
+	const can_data_t *channel = gs_host_frame_object_get_channel(hcan, frame_object);
+	const struct gs_host_frame *frame = &frame_object->frame;
 	uint8_t buf[CAN_DATA_MAX_PACKET_SIZE];
 	uint8_t *send_addr;
 	size_t len;
 
 	if (IS_ENABLED(CONFIG_CANFD) &&
 		frame->flags & GS_CAN_FLAG_FD) {
-		if (hcan->feature & GS_CAN_FEATURE_HW_TIMESTAMP) {
+		if (channel->feature & GS_CAN_FEATURE_HW_TIMESTAMP) {
 			len = struct_size(frame, canfd_ts, 1);
 		} else {
 			len = struct_size(frame, canfd, 1);
 		}
 	} else {
-		if (hcan->feature & GS_CAN_FEATURE_HW_TIMESTAMP) {
+		if (channel->feature & GS_CAN_FEATURE_HW_TIMESTAMP) {
 			len = struct_size(frame, classic_can_ts, 1);
 		} else {
 			len = struct_size(frame, classic_can, 1);
@@ -877,7 +881,7 @@ static uint8_t USBD_GS_CAN_SendFrame(USBD_HandleTypeDef *pdev, struct gs_host_fr
 	 * packet of 64 byte), so don't do any padding for CAN-FD frames
 	 * for now.
 	 */
-	if (hcan->feature & GS_CAN_FEATURE_PAD_PKTS_TO_MAX_PKT_SIZE &&
+	if (channel->feature & GS_CAN_FEATURE_PAD_PKTS_TO_MAX_PKT_SIZE &&
 		!((IS_ENABLED(CONFIG_CANFD) && frame->flags & GS_CAN_FLAG_FD))) {
 		memcpy(buf, frame, len);
 
@@ -911,7 +915,7 @@ void USBD_GS_CAN_SendToHost(USBD_HandleTypeDef *pdev)
 	list_del(&hcan->to_host_buf->list);
 	restore_irq(was_irq_enabled);
 
-	uint8_t result = USBD_GS_CAN_SendFrame(pdev, &hcan->to_host_buf->frame);
+	uint8_t result = USBD_GS_CAN_SendFrame(pdev, hcan->to_host_buf);
 	if (result == USBD_OK)
 		return;
 

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -1,28 +1,27 @@
 /*
-
-The MIT License (MIT)
-
-Copyright (c) 2016 Hubert Denkmair
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-*/
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Hubert Denkmair
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
 
 #include <stdlib.h>
 #include <string.h>

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -33,6 +33,7 @@
 #include "dfu.h"
 #include "gpio.h"
 #include "gs_usb.h"
+#include "host_frame.h"
 #include "led.h"
 #include "timer.h"
 #include "usbd_core.h"
@@ -560,9 +561,9 @@ static uint8_t USBD_GS_CAN_EP0_RxReady(USBD_HandleTypeDef *pdev) {
 				can_disable(channel);
 				led_set_mode(&channel->leds, LED_MODE_OFF);
 			} else if (mode->mode == GS_CAN_MODE_START) {
-				hcan->feature = mode->feature;
+				channel->feature = mode->feature;
 
-				can_enable(channel, mode->feature);
+				can_enable(channel);
 
 				led_set_mode(&channel->leds, LED_MODE_NORMAL);
 			}
@@ -842,22 +843,25 @@ static uint8_t USBD_GS_CAN_Transmit(USBD_HandleTypeDef *pdev, uint8_t *buf, uint
 	}
 }
 
-static uint8_t USBD_GS_CAN_SendFrame(USBD_HandleTypeDef *pdev, struct gs_host_frame *frame)
+static uint8_t USBD_GS_CAN_SendFrame(USBD_HandleTypeDef *pdev,
+									 struct gs_host_frame_object *frame_object)
 {
 	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*)pdev->pClassData;
+	const can_data_t *channel = gs_host_frame_object_get_channel(hcan, frame_object);
+	const struct gs_host_frame *frame = &frame_object->frame;
 	uint8_t buf[CAN_DATA_MAX_PACKET_SIZE];
 	uint8_t *send_addr;
 	size_t len;
 
 	if (IS_ENABLED(CONFIG_CANFD) &&
 		frame->flags & GS_CAN_FLAG_FD) {
-		if (hcan->feature & GS_CAN_FEATURE_HW_TIMESTAMP) {
+		if (channel->feature & GS_CAN_FEATURE_HW_TIMESTAMP) {
 			len = struct_size(frame, canfd_ts, 1);
 		} else {
 			len = struct_size(frame, canfd, 1);
 		}
 	} else {
-		if (hcan->feature & GS_CAN_FEATURE_HW_TIMESTAMP) {
+		if (channel->feature & GS_CAN_FEATURE_HW_TIMESTAMP) {
 			len = struct_size(frame, classic_can_ts, 1);
 		} else {
 			len = struct_size(frame, classic_can, 1);
@@ -876,7 +880,7 @@ static uint8_t USBD_GS_CAN_SendFrame(USBD_HandleTypeDef *pdev, struct gs_host_fr
 	 * packet of 64 byte), so don't do any padding for CAN-FD frames
 	 * for now.
 	 */
-	if (hcan->feature & GS_CAN_FEATURE_PAD_PKTS_TO_MAX_PKT_SIZE &&
+	if (channel->feature & GS_CAN_FEATURE_PAD_PKTS_TO_MAX_PKT_SIZE &&
 		!((IS_ENABLED(CONFIG_CANFD) && frame->flags & GS_CAN_FLAG_FD))) {
 		memcpy(buf, frame, len);
 
@@ -910,7 +914,7 @@ void USBD_GS_CAN_SendToHost(USBD_HandleTypeDef *pdev)
 	list_del(&hcan->to_host_buf->list);
 	restore_irq(was_irq_enabled);
 
-	uint8_t result = USBD_GS_CAN_SendFrame(pdev, &hcan->to_host_buf->frame);
+	uint8_t result = USBD_GS_CAN_SendFrame(pdev, hcan->to_host_buf);
 	if (result == USBD_OK)
 		return;
 


### PR DESCRIPTION
This is a preparation PR to support more than one CAN channel per board.

First all files that are touched, the existing license header is replace with a common one. The license text and the copyright stays the same.

Then coding style is adopted, an unused header file is removed.

The last patch moves the active features flag from `USBD_GS_CAN_HandleTypeDef::feature` to `can_data_t::feature`.