### PR TITLE
usbd_gs_can: recover USB/CAN state after host disconnect

### DIFF
--- a/cmake/arm-none-eabi-gcc.cmake
+++ b/cmake/arm-none-eabi-gcc.cmake
@@ -1,21 +1,35 @@
 set(TOOLCHAIN arm-none-eabi_14.2.rel1-1)
 
 find_path(TOOLCHAIN_BIN_DIR
-	NAMES arm-none-eabi-gcc
+	NAMES arm-none-eabi-gcc arm-none-eabi-gcc.exe
 	HINTS
 		ENV TOOLCHAIN_BIN_DIR
 		"$ENV{HOME}/${TOOLCHAIN}/bin"
 		"/opt/${TOOLCHAIN}/bin"
 		"/srv/${TOOLCHAIN}/bin"
 		"/usr/local/${TOOLCHAIN}/bin"
+		"C:/Program Files (x86)/Arm GNU Toolchain arm-none-eabi/14.2 rel1/bin"
 	DOC "Path to the ARM toolchain binaries"
 )
 
 set(CMAKE_SYSTEM_NAME Generic)
 set(CMAKE_SYSTEM_PROCESSOR arm)
 
-set(CMAKE_C_COMPILER "${TOOLCHAIN_BIN_DIR}/arm-none-eabi-gcc")
-set(CMAKE_C_COMPILER_TARGET arm-none-eabi)
+if(WIN32)
+	set(TOOLCHAIN_EXE_SUFFIX .exe)
+else()
+	set(TOOLCHAIN_EXE_SUFFIX "")
+endif()
 
-SET (CMAKE_C_COMPILER_WORKS 1)
-SET (CMAKE_CXX_COMPILER_WORKS 1)
+set(CMAKE_C_COMPILER "${TOOLCHAIN_BIN_DIR}/arm-none-eabi-gcc${TOOLCHAIN_EXE_SUFFIX}")
+set(CMAKE_ASM_COMPILER "${TOOLCHAIN_BIN_DIR}/arm-none-eabi-gcc${TOOLCHAIN_EXE_SUFFIX}")
+set(CMAKE_C_COMPILER_TARGET arm-none-eabi)
+set(CMAKE_AR "${TOOLCHAIN_BIN_DIR}/arm-none-eabi-gcc-ar${TOOLCHAIN_EXE_SUFFIX}")
+set(CMAKE_RANLIB "${TOOLCHAIN_BIN_DIR}/arm-none-eabi-gcc-ranlib${TOOLCHAIN_EXE_SUFFIX}")
+set(CMAKE_LINKER "${TOOLCHAIN_BIN_DIR}/arm-none-eabi-gcc${TOOLCHAIN_EXE_SUFFIX}")
+set(CMAKE_OBJCOPY "${TOOLCHAIN_BIN_DIR}/arm-none-eabi-objcopy${TOOLCHAIN_EXE_SUFFIX}")
+set(CMAKE_SIZE "${TOOLCHAIN_BIN_DIR}/arm-none-eabi-size${TOOLCHAIN_EXE_SUFFIX}")
+
+SET(CMAKE_C_COMPILER_WORKS 1)
+SET(CMAKE_CXX_COMPILER_WORKS 1)
+SET(CMAKE_ASM_COMPILER_WORKS 1)

--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -131,6 +131,7 @@ typedef struct {
 uint8_t USBD_GS_CAN_Init(USBD_GS_CAN_HandleTypeDef *hcan, USBD_HandleTypeDef *pdev);
 void USBD_GS_CAN_SuspendCallback(USBD_HandleTypeDef  *pdev);
 void USBD_GS_CAN_ResumeCallback(USBD_HandleTypeDef  *pdev);
+void USBD_GS_CAN_CheckHostPresence(USBD_HandleTypeDef *pdev);
 void USBD_GS_CAN_ReceiveFromHost(USBD_HandleTypeDef *pdev);
 void USBD_GS_CAN_SendToHost(USBD_HandleTypeDef *pdev);
 bool USBD_GS_CAN_CustomDeviceRequest(USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef *req);

--- a/src/main.c
+++ b/src/main.c
@@ -109,6 +109,7 @@ int main(void)
 			CAN_SendFrame(&hGS_CAN, channel);
 		}
 
+		USBD_GS_CAN_CheckHostPresence(&hUSB);
 		USBD_GS_CAN_ReceiveFromHost(&hUSB);
 		USBD_GS_CAN_SendToHost(&hUSB);
 

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -46,6 +46,20 @@ THE SOFTWARE.
 #include "util.h"
 
 static volatile bool is_usb_suspend_cb = false;
+static volatile bool sof_seen;
+
+/* Drop a stuck IN transfer buffer (replaces legacy TxState reset on resume). */
+static void USBD_GS_CAN_ReleaseToHostBuf(USBD_GS_CAN_HandleTypeDef *hcan)
+{
+	bool was_irq_enabled = disable_irq();
+
+	if (hcan->to_host_buf) {
+		list_add_tail(&hcan->to_host_buf->list, &hcan->list_frame_pool);
+		hcan->to_host_buf = NULL;
+	}
+
+	restore_irq(was_irq_enabled);
+}
 
 /* Configuration Descriptor */
 static const uint8_t USBD_GS_CAN_CfgDesc[USB_CAN_CONFIG_DESC_SIZ] =
@@ -254,7 +268,15 @@ static uint8_t USBD_GS_CAN_Start(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
 
 static uint8_t USBD_GS_CAN_DeInit(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
 {
+	USBD_GS_CAN_HandleTypeDef *hcan = pdev->pClassData;
+
 	UNUSED(cfgidx);
+
+	if (hcan)
+		USBD_GS_CAN_ReleaseToHostBuf(hcan);
+
+	sof_seen = false;
+	is_usb_suspend_cb = false;
 
 	USBD_LL_CloseEP(pdev, GSUSB_ENDPOINT_IN);
 	USBD_LL_CloseEP(pdev, GSUSB_ENDPOINT_OUT);
@@ -729,6 +751,8 @@ out_prepare_receive:
 static uint8_t USBD_GS_CAN_SOF(struct _USBD_HandleTypeDef *pdev)
 {
 	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*) pdev->pClassData;
+
+	sof_seen = true;
 	hcan->sof_timestamp_us = timer_get();
 	return USBD_OK;
 }
@@ -940,11 +964,45 @@ void USBD_GS_CAN_SuspendCallback(USBD_HandleTypeDef  *pdev)
 		led_set_mode(&channel->leds, LED_MODE_OFF);
 	}
 
+	USBD_GS_CAN_ReleaseToHostBuf(hcan);
 	is_usb_suspend_cb = true;
 }
 
 void USBD_GS_CAN_ResumeCallback(USBD_HandleTypeDef  *pdev)
 {
-	(void)pdev;
+	USBD_GS_CAN_HandleTypeDef *hcan = pdev->pClassData;
+
+	USBD_GS_CAN_ReleaseToHostBuf(hcan);
 	is_usb_suspend_cb = false;
+}
+
+#define USB_SOF_WATCHDOG_TIMEOUT_US 200000U
+
+void USBD_GS_CAN_CheckHostPresence(USBD_HandleTypeDef *pdev)
+{
+	USBD_GS_CAN_HandleTypeDef *hcan = pdev->pClassData;
+	uint32_t now;
+	uint32_t elapsed;
+
+	if (is_usb_suspend_cb || pdev->dev_state != USBD_STATE_CONFIGURED || !sof_seen)
+		return;
+
+	now = timer_get();
+	elapsed = now - hcan->sof_timestamp_us;
+	if (elapsed < USB_SOF_WATCHDOG_TIMEOUT_US)
+		return;
+
+	sof_seen = false;
+
+	for (unsigned int i = 0; i < ARRAY_SIZE(hcan->channels); i++) {
+		can_data_t *channel = &hcan->channels[i];
+
+		if (!can_is_enabled(channel))
+			continue;
+
+		can_disable(channel);
+		led_set_mode(&channel->leds, LED_MODE_OFF);
+	}
+
+	USBD_GS_CAN_ReleaseToHostBuf(hcan);
 }


### PR DESCRIPTION
## Summary

Fixes #46. Fixes #266.

USB-CAN adapters can stop responding after a host reboot without a power cycle (STM32 stays powered, USB suspend may not occur). Reported with FYSETC UCAN on Proxmox USB passthrough.

- Release stuck `to_host_buf` on USB suspend, resume, and USB `DeInit` (replaces legacy `TxState = 0` from #94).
- SOF watchdog (~200 ms): disable CAN when the host stops Start-of-Frame without proper USB suspend.

Tested on FYSETC UCAN (STM32F072) with host and LXC reboots (Proxmox USB passthrough).

## Changes

- `src/usbd_gs_can.c`, `src/main.c`, `include/usbd_gs_can.h` — recovery logic
- `cmake/arm-none-eabi-gcc.cmake` — Windows toolchain path / LTO (`gcc-ar`)

## Test plan

- [ ] Flash any STM32F072-based gs_usb device
- [ ] Reboot host or VM guest with active `can0` (without `ip link set can0 down` first)
- [ ] After boot, bring up `can0` and verify CAN traffic
- [ ] Optional: verify USB suspend/resume still works
