### PR TITLE
codespell: fix codespellrc

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 # -*-conf-*-
 
-[Codespellini]
+[codespell]
 ignore-words-list=cantact


### PR DESCRIPTION
Fix section name in `.codespellrc`

Fixes: f5a89633ed9f ("CMakeLists: add codespell target")