### PR TITLE
add more no-ops that overwrite newlib functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,6 +131,7 @@ set(
 
 	src/interrupts.c
 	src/main.c
+	src/no-op.c
 	src/startup.c
 
 	${CMAKE_CURRENT_BINARY_DIR}/version.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,9 +129,9 @@ set(
 	include/timer.h src/timer.c
 	include/util.h src/util.c
 
-	src/startup.c
-	src/main.c
 	src/interrupts.c
+	src/main.c
+	src/startup.c
 
 	${CMAKE_CURRENT_BINARY_DIR}/version.h
 )

--- a/src/main.c
+++ b/src/main.c
@@ -49,15 +49,6 @@ THE SOFTWARE.
 static USBD_GS_CAN_HandleTypeDef hGS_CAN;
 static USBD_HandleTypeDef hUSB = {0};
 
-void __weak _close(void) {
-}
-void __weak _lseek(void) {
-}
-void __weak _read(void) {
-}
-void __weak _write(void) {
-}
-
 int main(void)
 {
 	HAL_Init();

--- a/src/no-op.c
+++ b/src/no-op.c
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2024 Marc Kleine-Budde <kernel@pengutronix.de>
+ * Copyright (c) 2024, 2026 Marc Kleine-Budde <kernel@pengutronix.de>
  * Copyright (c) fenugrec 2022
  * Copyright (c) 2019 Hubert Denkmair
  *
@@ -24,6 +24,10 @@
  * THE SOFTWARE.
  *
  */
+
+void __libc_fini_array(void)
+{
+}
 
 void __register_exitproc(void)
 {

--- a/src/no-op.c
+++ b/src/no-op.c
@@ -2,6 +2,7 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2024 Marc Kleine-Budde <kernel@pengutronix.de>
+ * Copyright (c) fenugrec 2022
  * Copyright (c) 2019 Hubert Denkmair
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -23,6 +24,10 @@
  * THE SOFTWARE.
  *
  */
+
+void __register_exitproc(void)
+{
+}
 
 void _close(void)
 {

--- a/src/no-op.c
+++ b/src/no-op.c
@@ -25,11 +25,9 @@
  *
  */
 
-void __libc_fini_array(void)
-{
-}
+#include <compiler.h>
 
-void __register_exitproc(void)
+void __libc_fini_array(void)
 {
 }
 
@@ -54,4 +52,9 @@ void _read(void)
 
 void _write(void)
 {
+}
+
+int atexit(void __maybe_unused (*fn)(void))
+{
+	return 0;
 }

--- a/src/no-op.c
+++ b/src/no-op.c
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2024 Marc Kleine-Budde <kernel@pengutronix.de>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+void _close(void)
+{
+}
+
+void _lseek(void)
+{
+}
+
+void _read(void)
+{
+}
+
+void _write(void)
+{
+}

--- a/src/no-op.c
+++ b/src/no-op.c
@@ -2,6 +2,7 @@
  * The MIT License (MIT)
  *
  * Copyright (c) 2024 Marc Kleine-Budde <kernel@pengutronix.de>
+ * Copyright (c) 2019 Hubert Denkmair
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,6 +26,13 @@
 
 void _close(void)
 {
+}
+
+void _exit(int code)
+{
+	(void) code;
+	__asm__ ("BKPT");
+	while (1);
 }
 
 void _lseek(void)

--- a/src/no-op.c
+++ b/src/no-op.c
@@ -35,13 +35,6 @@ void _close(void)
 {
 }
 
-void _exit(int code)
-{
-	(void) code;
-	__asm__ ("BKPT");
-	while (1);
-}
-
 void _lseek(void)
 {
 }
@@ -57,4 +50,10 @@ void _write(void)
 int atexit(void __maybe_unused (*fn)(void))
 {
 	return 0;
+}
+
+void exit(int __maybe_unused code)
+{
+	__asm__ ("BKPT");
+	while (1);
 }

--- a/src/startup.c
+++ b/src/startup.c
@@ -54,10 +54,3 @@ void Reset_Handler(void)
 void __register_exitproc(void) {
 	return;
 }
-
-void _exit(int code)
-{
-	(void) code;
-	__asm__ ("BKPT");
-	while (1);
-}

--- a/src/startup.c
+++ b/src/startup.c
@@ -1,3 +1,28 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Hubert Denkmair
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>

--- a/src/startup.c
+++ b/src/startup.c
@@ -50,7 +50,3 @@ void Reset_Handler(void)
 
 	_start();
 }
-
-void __register_exitproc(void) {
-	return;
-}


### PR DESCRIPTION
This saves ~425 bytes of a non-lto `-O2` build of the candleLight_fw.

```
add/remove: 1/5 grow/shrink: 0/5 up/down: 4/-430 (-426)
Function                                     old     new   delta
__do_global_dtors_aux_fini_array_entry         -       4      +4
__register_exitproc                            2       -      -2
$t                                          3003    3001      -2
_exit                                          4       -      -4
__stdio_exit_handler                           4       -      -4
__fini_array_start                             4       -      -4
atexit                                        16       4     -12
$d                                          1480    1464     -16
exit                                          40       4     -36
__libc_fini_array                             40       2     -38
__sf                                         312       -    -312
Total: Before=28342, After=27916, chg -1.50%
```