### PR TITLE
fix "LOAD segment with RWX permissions" warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 	set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release")
 endif()
 
+####### check for newlib and picolibc
+
 include(CheckSymbolExists)
 
 check_symbol_exists(__PICOLIBC__ "sys/features.h" HAVE_PICOLIBC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,16 @@ else()
 	message(FATAL_ERROR "Neither Picolibc nor Newlib detected.")
 endif()
 
+####### check linker not supporting "(READONLY)"
+
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_LESS "11.0")
+    set(HAVE_READONLY FALSE CACHE INTERNAL "Linker does not support (READONLY) keyword")
+    message(STATUS "Disabling Linker (READONLY) flag")
+else()
+    set(HAVE_READONLY TRUE CACHE INTERNAL "Linker supports (READONLY) keyword")
+    message(STATUS "Enabling linker (READONLY) flag")
+endif()
+
 add_compile_options(
 	$<$<CONFIG:Debug>:-O2>
 	$<$<CONFIG:Release>:-O3>
@@ -210,6 +220,12 @@ function(populate_ldscript)
 		HEAP_SIZE)
 	set(multiValueArgs)
 	cmake_parse_arguments("${prefix}" "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+	if(HAVE_READONLY)
+		set(LDV_READONLY "(READONLY)")
+	else()
+		set(LDV_READONLY "")
+	endif()
 
 	# now we should have function-scope vars like LDV_FLASH_SIZE etc.
 

--- a/ldscripts/ldscript_base.inc
+++ b/ldscripts/ldscript_base.inc
@@ -69,7 +69,7 @@ SECTIONS
 		KEEP(*(.eh_frame*))
 	} > FLASH
 
-	.copy.table :
+	.copy.table @READONLY@ :
 	{
 		. = ALIGN(4);
 		__copy_table_start__ = .;
@@ -79,7 +79,7 @@ SECTIONS
 		__copy_table_end__ = .;
 	} > FLASH
 
-	.preinit_array :
+	.preinit_array @READONLY@ :
 	{
 		. = ALIGN(4);
 		/* preinit data */
@@ -89,7 +89,7 @@ SECTIONS
 		. = ALIGN(4);
 	} >FLASH
 
-	.init_array :
+	.init_array @READONLY@ :
 	{
 		. = ALIGN(4);
 		/* init data */


### PR DESCRIPTION
The linker treats the `.copy.table`, `.preinit_array`, and `.init_array` sections as data, which are writable by default. Explicitly mark them as `READONLY` (on supported linkers) to fix this warning:

```
warning: candleLight_fw has a LOAD segment with RWX permissions
```

Closes: https://github.com/candle-usb/candleLight_fw/issues/106