### PR TITLE
cmake: fix LTO builds with "Arm GNU Toolchain"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,9 +43,10 @@ else()
     message(STATUS "Enabling linker (READONLY) flag")
 endif()
 
+set(CMAKE_C_FLAGS_RELEASE "-O3")
+set(CMAKE_C_FLAGS_DEBUG "-O2")
+
 add_compile_options(
-	$<$<CONFIG:Debug>:-O2>
-	$<$<CONFIG:Release>:-O3>
 	$<$<CONFIG:Release>:-flto>
 	$<$<CONFIG:Release>:-fno-fat-lto-objects>
 	${LIBC_OPTIONS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,9 +46,10 @@ endif()
 set(CMAKE_C_FLAGS_RELEASE "-O3")
 set(CMAKE_C_FLAGS_DEBUG "-O2")
 
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_RELEASE TRUE)
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION_DEBUG FALSE)
+
 add_compile_options(
-	$<$<CONFIG:Release>:-flto>
-	$<$<CONFIG:Release>:-fno-fat-lto-objects>
 	${LIBC_OPTIONS}
 	-Wall
 	-Werror
@@ -70,7 +71,6 @@ set(CPUFLAGS_F4 -mcpu=cortex-m4)
 set(CPUFLAGS_G0 -mcpu=cortex-m0)
 
 add_link_options(
-	$<$<CONFIG:Release>:-flto>
 	${LIBC_OPTIONS}
 	-Wall
 	-Wextra


### PR DESCRIPTION
In the default installation, `ar` and `ranlib` of the "Arm GNU Toolchain", don't find the LTO plugin.

By switching on LTO via cmake's `CMAKE_INTERPROCEDURAL_OPTIMIZATION`, cmake picks up the plugin aware wrappers `gcc-ar` and `gcc-ranlib`.