### PR TITLE
add support for ARM semihosting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 #
 # The MIT License (MIT)
 #
+# Copyright (c) 2026 Marc Kleine-Budde <kernel@pengutronix.de>
 # Copyright (c) 2019 Hubert Denkmair
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -35,6 +36,10 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
 	# Set the possible values for cmake-gui drop-down
 	set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release")
 endif()
+
+######## options
+
+option(ENABLE_SEMIHOSTING "Enable semihosting support for debugging" OFF)
 
 ######## libc selection
 
@@ -76,9 +81,27 @@ if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
 	if(LIBC STREQUAL "newlib")
 		add_link_options(
 			-specs=nano.specs
-			-specs=nosys.specs
 		)
+		if(ENABLE_SEMIHOSTING)
+			add_link_options(
+				-specs=rdimon.specs
+				-lrdimon
+			)
+		else()
+			add_link_options(
+				-specs=nosys.specs
+			)
+		endif()
 	endif()
+endif()
+
+######## semihosting
+
+if(ENABLE_SEMIHOSTING)
+	message(STATUS "Semihosting: enabled")
+	add_compile_definitions(CONFIG_SEMIHOSTING=1)
+else()
+	message(STATUS "Semihosting: disabled")
 endif()
 
 ####### check linker not supporting "(READONLY)"

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -52,6 +52,10 @@
 #define fallthrough do {} while (0) /* fallthrough */
 #endif
 
+#ifndef __weak
+#define __weak  __attribute__((weak))
+#endif
+
 #define barrier()	   __asm__ __volatile__ ("" : : : "memory")
 
 #define ACCESS_ONCE(x) (*(volatile __typeof(x) *)&(x))

--- a/include/compiler.h
+++ b/include/compiler.h
@@ -53,7 +53,7 @@
 #endif
 
 #ifndef __weak
-#define __weak  __attribute__((weak))
+#define __weak __attribute__((weak))
 #endif
 
 #define barrier()	   __asm__ __volatile__ ("" : : : "memory")

--- a/src/main.c
+++ b/src/main.c
@@ -43,7 +43,7 @@
 #include "usbd_gs_can.h"
 
 static USBD_GS_CAN_HandleTypeDef hGS_CAN;
-static USBD_HandleTypeDef hUSB = {0};
+static USBD_HandleTypeDef hUSB;
 
 int main(void)
 {
@@ -72,12 +72,11 @@ int main(void)
 				 LEDRX_GPIO_Port, LEDRX_Pin, LEDRX_Active_High,
 				 LEDTX_GPIO_Port, LEDTX_Pin, LEDTX_Active_High);
 
-
 		can_init(channel, channel_config);
 		can_disable(channel);
 	}
 
-	USBD_Init(&hUSB, (USBD_DescriptorsTypeDef*)&FS_Desc, DEVICE_FS);
+	USBD_Init(&hUSB, (USBD_DescriptorsTypeDef *)&FS_Desc, DEVICE_FS);
 	USBD_RegisterClass(&hUSB, &USBD_GS_CAN);
 	USBD_GS_CAN_Init(&hGS_CAN, &hUSB);
 	USBD_Start(&hUSB);

--- a/src/main.c
+++ b/src/main.c
@@ -1,28 +1,27 @@
 /*
-
-The MIT License (MIT)
-
-Copyright (c) 2016 Hubert Denkmair
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-*/
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Hubert Denkmair
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/src/main.c
+++ b/src/main.c
@@ -34,8 +34,6 @@
 #include "device.h"
 #include "dfu.h"
 #include "gpio.h"
-#include "gs_usb.h"
-#include "hal_include.h"
 #include "led.h"
 #include "timer.h"
 #include "usbd_conf.h"
@@ -43,7 +41,6 @@
 #include "usbd_def.h"
 #include "usbd_desc.h"
 #include "usbd_gs_can.h"
-#include "util.h"
 
 static USBD_GS_CAN_HandleTypeDef hGS_CAN;
 static USBD_HandleTypeDef hUSB = {0};

--- a/src/main.c
+++ b/src/main.c
@@ -42,11 +42,16 @@
 #include "usbd_desc.h"
 #include "usbd_gs_can.h"
 
+void initialise_monitor_handles(void);
+
 static USBD_GS_CAN_HandleTypeDef hGS_CAN;
 static USBD_HandleTypeDef hUSB;
 
 int main(void)
 {
+	if (IS_ENABLED(CONFIG_SEMIHOSTING))
+		 initialise_monitor_handles();
+
 	HAL_Init();
 	device_sysclock_config();
 

--- a/src/main.c
+++ b/src/main.c
@@ -50,7 +50,7 @@ static USBD_HandleTypeDef hUSB;
 int main(void)
 {
 	if (IS_ENABLED(CONFIG_SEMIHOSTING))
-		 initialise_monitor_handles();
+		initialise_monitor_handles();
 
 	HAL_Init();
 	device_sysclock_config();

--- a/src/no-op.c
+++ b/src/no-op.c
@@ -31,19 +31,19 @@ void __libc_fini_array(void)
 {
 }
 
-void _close(void)
+void __weak _close(void)
 {
 }
 
-void _lseek(void)
+void __weak _lseek(void)
 {
 }
 
-void _read(void)
+void __weak _read(void)
 {
 }
 
-void _write(void)
+void __weak _write(void)
 {
 }
 


### PR DESCRIPTION
As usual, all files touched, clean up the coding style, make sure they have a license header. Add needed `initialise_monitor_handles();` in `main()` and finally add an option in cmake.