### PR TITLE
hal include: fix clangd warning

### DIFF
--- a/libs/STM32_HAL/config/hal_include.h
+++ b/libs/STM32_HAL/config/hal_include.h
@@ -26,9 +26,9 @@
 #pragma once
 
 #if defined(STM32F0)
-# include "stm32f0xx_hal.h"
+#include "stm32f0xx_hal.h"
 #elif defined(STM32F4)
-# include "stm32f4xx_hal.h"
+#include "stm32f4xx_hal.h"
 #elif defined(STM32G0)
 # include "stm32g0xx_hal.h"
 #endif

--- a/libs/STM32_HAL/config/hal_include.h
+++ b/libs/STM32_HAL/config/hal_include.h
@@ -1,28 +1,27 @@
 /*
-
-The MIT License (MIT)
-
-Copyright (c) 2016 Hubert Denkmair
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-*/
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Hubert Denkmair
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
 
 #pragma once
 

--- a/libs/STM32_HAL/config/hal_include.h
+++ b/libs/STM32_HAL/config/hal_include.h
@@ -26,9 +26,9 @@
 #pragma once
 
 #if defined(STM32F0)
-#include "stm32f0xx_hal.h"
+#include "stm32f0xx_hal.h"  // IWYU pragma: export
 #elif defined(STM32F4)
-#include "stm32f4xx_hal.h"
+#include "stm32f4xx_hal.h"  // IWYU pragma: export
 #elif defined(STM32G0)
-# include "stm32g0xx_hal.h"
+# include "stm32g0xx_hal.h" // IWYU pragma: export
 #endif


### PR DESCRIPTION
Silences the following warning with `clangd`:

```
clangd [unused-includes]: Included header hal_include.h is not used directly
````