### PR TITLE
usbd_gs_can: add buffer length check

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -122,6 +122,28 @@
 #define min(x, y) ((x) < (y) ? (x) : (y))
 #define max(x, y) ((x) > (y) ? (x) : (y))
 
+/*
+ * BUILD_BUG_ON() can happen inside functions where _Static_assert() does not
+ * seem to work.  Use old-schoold-ish CTASSERT from before commit
+ * a3085588a88fa58eb5b1eaae471999e1995a29cf but also make sure we do not
+ * end up with an unused typedef or variable. The compiler should optimise
+ * it away entirely.
+ */
+#define _O_CTASSERT(x)				   _O__CTASSERT(x, __LINE__)
+#define _O__CTASSERT(x, y)			   _O___CTASSERT(x, y)
+#define _O___CTASSERT(x, y)			   while (0) { \
+			typedef char __assert_line_ ## y[(x) ? 1 : -1]; \
+			__assert_line_ ## y _x __unused; \
+			_x[0] = '\0'; \
+}
+
+#define BUILD_BUG()					   do { CTASSERT(0); } while (0)
+#define BUILD_BUG_ON(x)				   do { _O_CTASSERT(!(x)) } while (0)
+#define BUILD_BUG_ON_MSG(x, msg)	   BUILD_BUG_ON(x)
+#define BUILD_BUG_ON_NOT_POWER_OF_2(x) BUILD_BUG_ON(!powerof2(x))
+#define BUILD_BUG_ON_INVALID(expr)	   while (0) { (void)(expr); }
+#define BUILD_BUG_ON_ZERO(x)		   ((int)sizeof(struct { int: -((x) != 0); }))
+
 #undef static_assert
 #define static_assert(x, ...)		 __static_assert(x, ## __VA_ARGS__, #x)
 #define __static_assert(x, msg, ...) _Static_assert(x, msg)

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -741,6 +741,7 @@ static uint8_t *USBD_GS_CAN_GetCfgDesc(uint16_t *len)
 	 */
 	*len = sizeof(USBD_GS_CAN_CfgDesc);
 	memcpy(USBD_DescBuf, USBD_GS_CAN_CfgDesc, sizeof(USBD_GS_CAN_CfgDesc));
+	BUILD_BUG_ON(sizeof(USBD_GS_CAN_CfgDesc) >= sizeof(USBD_DescBuf));
 
 	return USBD_DescBuf;
 }
@@ -756,6 +757,7 @@ uint8_t *USBD_GS_CAN_GetStrDesc(USBD_HandleTypeDef *pdev, uint8_t index, uint16_
 		case 0xEE:
 			*length = sizeof(USBD_GS_CAN_WINUSB_STR);
 			memcpy(USBD_DescBuf, USBD_GS_CAN_WINUSB_STR, sizeof(USBD_GS_CAN_WINUSB_STR));
+			BUILD_BUG_ON(sizeof(USBD_GS_CAN_WINUSB_STR) >= sizeof(USBD_DescBuf));
 			return USBD_DescBuf;
 		default:
 			*length = 0;
@@ -794,12 +796,14 @@ bool USBD_GS_CAN_CustomDeviceRequest(USBD_HandleTypeDef *pdev, USBD_SetupReqType
 
 			case 0x0004:
 				memcpy(USBD_DescBuf, USBD_MS_COMP_ID_FEATURE_DESC, sizeof(USBD_MS_COMP_ID_FEATURE_DESC));
+				BUILD_BUG_ON(sizeof(USBD_MS_COMP_ID_FEATURE_DESC) >= sizeof(USBD_DescBuf));
 				USBD_CtlSendData(pdev, USBD_DescBuf, MIN(sizeof(USBD_MS_COMP_ID_FEATURE_DESC), req->wLength));
 				return true;
 
 			case 0x0005:
 				if (req->wValue==0) { // only return our GUID for interface #0
 					memcpy(USBD_DescBuf, USBD_MS_EXT_PROP_FEATURE_DESC, sizeof(USBD_MS_EXT_PROP_FEATURE_DESC));
+					BUILD_BUG_ON(sizeof(USBD_MS_EXT_PROP_FEATURE_DESC) >= sizeof(USBD_DescBuf));
 					USBD_CtlSendData(pdev, USBD_DescBuf, MIN(sizeof(USBD_MS_EXT_PROP_FEATURE_DESC), req->wLength));
 					return true;
 				}


### PR DESCRIPTION
Avoid potential future buffer overflows of the `USBD_DescBuf` buffer. Add `BUILD_BUG_ON()` to detect them during compile time.

Closes: https://github.com/candle-usb/candleLight_fw/pull/291