### PR TITLE
compiler: `BUILD_BUG()`: fix clangd warning

### DIFF
--- a/include/compiler.h
+++ b/include/compiler.h
@@ -133,7 +133,7 @@
 #define _O__CTASSERT(x, y)			   _O___CTASSERT(x, y)
 #define _O___CTASSERT(x, y)			   while (0) { \
 			typedef char __assert_line_ ## y[(x) ? 1 : -1]; \
-			__assert_line_ ## y _x __unused; \
+			__assert_line_ ## y _x __maybe_unused; \
 			_x[0] = '\0'; \
 }
 


### PR DESCRIPTION
`__unused` is not defined, use `__maybe_unused` instead.