### PR TITLE
README: add EcuBus-Pro link to related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,3 +177,4 @@ The .out file can then be processed with `gprof <firmware_name> -l test.out`
 ## Links to related projects
 * [Cangaroo](https://github.com/HubertD/cangaroo) open source can bus analyzer software
 * [Candle.NET](https://github.com/elliotwoods/Candle.NET) .NET wrapper for the candle API
+* [EcuBus-Pro](https://github.com/ecubus/EcuBus-Pro) a powerful automotive ECU development tool


### PR DESCRIPTION
I recently contributed to EcuBus-Pro (ecubus/EcuBus-Pro#379) to improve
Candle device compatibility. The changes enable EcuBus-Pro to work
seamlessly with candleLight_fw.

Tested with:
- Canable 1.0 (F072) running candleLight_fw firmware
- Canable 2.0 (G431) running CANable-2.5-firmware-Slcan-and-Candlelight firmware

Both CAN and CANFD work as expected. I'm adding this link so more people
discover this great tool.

<img width="3829" height="2153" alt="image" src="https://github.com/user-attachments/assets/cb68a701-2623-4172-b554-b44dc60e6138" />
