### PR TITLE
Add board profile for Jhoinrch RH02

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -429,6 +429,7 @@ set(TGTF072_LIST
 	"CONVERTDEVICE_xCAN"
 	"DSD_TECH_SH_C30A"
 	"FYSETC_UCAN"
+	"RH02"
 	"can_module_com_classic"
 	"candleLight"
 )

--- a/include/config.h
+++ b/include/config.h
@@ -288,6 +288,29 @@ THE SOFTWARE.
 	#define LEDTX_Mode				 GPIO_MODE_OUTPUT_PP
 	#define LEDTX_Active_High		 1
 
+#elif defined(BOARD_RH02)
+	#define USBD_PRODUCT_STRING_FS	 "RH02 gs_usb"
+	#define USBD_MANUFACTURER_STRING "Jhoinrch"
+	#define DFU_INTERFACE_STRING_FS	 "Jhoinrch RH02 firmware upgrade interface"
+
+	#define CONFIG_HSE_OSC_SPEED	 24000000
+	#define TIM2_CLOCK_SPEED		 48000000
+
+	#define CAN_INTERFACE			 CAN
+	#define CAN_CLOCK_SPEED			 48000000
+	#define NUM_CAN_CHANNEL			 1
+	#define CONFIG_CAN_FILTER		 1
+
+	#define LEDRX_GPIO_Port			 GPIOB
+	#define LEDRX_Pin				 GPIO_PIN_0
+	#define LEDRX_Mode				 GPIO_MODE_OUTPUT_PP
+	#define LEDRX_Active_High		 1
+
+	#define LEDTX_GPIO_Port			 GPIOB
+	#define LEDTX_Pin				 GPIO_PIN_1
+	#define LEDTX_Mode				 GPIO_MODE_OUTPUT_PP
+	#define LEDTX_Active_High		 1
+
 #elif defined(BOARD_can_module_com_classic)
 	#define USBD_PRODUCT_STRING_FS	 "USBCAN ADAPTER"
 	#define USBD_MANUFACTURER_STRING "can-module.com"


### PR DESCRIPTION
Howdy howdy.

I wanted to do two things with this PR.

1. Add support for the Jhoinrch RH02
2. Inform you of the settings needed for the Jhoinrch RH02 Plus (2026) once `STM32G431` support lands. (Since I'm lazy and I don't wanna do another PR once it does ;P) I've tested it with the `CANable2_MKS` profile in @marckleinebudde's [`multichannel` branch](https://github.com/marckleinebudde/candleLight_fw/actions/runs/23597653754) successfully!

The Jhoinrch RH02 line of devices are cheaply available, on Amazon and other retailers, yet I haven't seen any firmwares that support them and their hardware properly (either the crystal is ignored, or the LEDs have incorrect mappings/active levels).

The base RH02 is using the `STM32F072C8`, with a 24MHz crystal on-board.

The RH02 Plus (2026) uses the `STM32G431CB`, with a 2*5*MHz crystal on-board, with State/Activity LEDs rather than RX/TX. The blue STATE led is on PD2, Active Low. The Purple WORD led is on PD3, Active Low.

I denote 2026 because according to [Elmue](https://netcult.ch/elmue/CANable%20Firmware%20Update/#Adapters), it only started shipping with the 25MHz crystal this year.

Thanks for maintaining this firmware, and continuing to improve the gs_usb spec! (Especially Elmue and Marc!!!) <3

I intend to also submit a PR to CANnectivity shortly.