### PR TITLE
CMakeLists: build with `-D_FORTIFY_SOURCE=2`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,8 @@ add_compile_options(
 	-std=gnu11
 )
 
+add_compile_definitions(_FORTIFY_SOURCE=2)
+
 # need these later, per-platform
 set(CPUFLAGS_F0 -mcpu=cortex-m0)
 set(CPUFLAGS_F4 -mcpu=cortex-m4)


### PR DESCRIPTION
This saves ~4 bytes of a non-lto `-O2` build of the candleLight_fw.

```
add/remove: 0/6 grow/shrink: 2/1 up/down: 308/-312 (-4)
Function                                     old     new   delta
$d                                          1460    1764    +304
USBD_FS_DeviceDescriptor                      32      36      +4
USBD_LangIDDesc                                4       -      -4
USBD_FS_LangIDStrDescriptor                   32      20     -12
USBD_GS_CAN_WINUSB_STR                        18       -     -18
USBD_FS_DeviceDesc                            18       -     -18
USBD_GS_CAN_CfgDesc                           50       -     -50
USBD_MS_COMP_ID_FEATURE_DESC                  64       -     -64
USBD_MS_EXT_PROP_FEATURE_DESC                146       -    -146
Total: Before=27868, After=27864, chg -0.01%
```