### PR TITLE
fix stuck USB IN transfer (device -> host) after USB suspend or host reboot

### DIFF
--- a/include/can.h
+++ b/include/can.h
@@ -34,7 +34,7 @@
 #include "led.h"
 #include "list.h"
 
-typedef struct {
+typedef struct can_channel {
 #if defined (CONFIG_BXCAN)
 	CAN_TypeDef *instance;
 #endif
@@ -83,8 +83,6 @@ static inline void can_set_filter(can_data_t *channel, const struct gs_device_fi
 }
 #endif
 
-void can_enable(can_data_t *channel);
-void can_disable(can_data_t *channel);
 bool can_is_enabled(can_data_t *channel);
 
 bool can_receive(can_data_t *channel, struct gs_host_frame *rx_frame);

--- a/include/can_common.h
+++ b/include/can_common.h
@@ -1,28 +1,27 @@
 /*
-
-The MIT License (MIT)
-
-Copyright (c) 2016 Hubert Denkmair
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-*/
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Hubert Denkmair
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
 
 #pragma once
 

--- a/include/can_common.h
+++ b/include/can_common.h
@@ -64,6 +64,9 @@ static inline u8 can_channel_get_nr(const can_data_t __maybe_unused *channel)
 }
 #endif
 
+void can_enable(struct can_channel *channel, uint32_t mode);
+void can_disable(USBD_GS_CAN_HandleTypeDef *hcan, struct can_channel *channel);
+
 void CAN_SendFrame(USBD_GS_CAN_HandleTypeDef *hcan, can_data_t *channel);
 void CAN_ReceiveFrame(USBD_GS_CAN_HandleTypeDef *hcan, can_data_t *channel);
 void CAN_HandleError(USBD_GS_CAN_HandleTypeDef *hcan, can_data_t *channel);

--- a/include/can_drv.h
+++ b/include/can_drv.h
@@ -1,0 +1,33 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2026 Marc Kleine-Budde <kernel@pengutronix.de>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+struct can_channel;
+
+void can_drv_enable(struct can_channel *channel);
+void can_drv_disable(struct can_channel *channel);

--- a/include/host_frame.h
+++ b/include/host_frame.h
@@ -29,14 +29,20 @@
 #include "config.h"
 #include "usbd_gs_can.h"
 
+static inline u8
+gs_host_frame_object_get_channel_nr(const struct gs_host_frame_object *frame_object)
+{
+	if (NUM_CAN_CHANNEL > 1)
+		return frame_object->frame.channel;
+
+	return 0;
+}
+
 static inline can_data_t *
 gs_host_frame_object_get_channel(USBD_GS_CAN_HandleTypeDef *hcan,
 								 const struct gs_host_frame_object *frame_object)
 {
-	u8 channel_nr = 0;
-
-	if (NUM_CAN_CHANNEL > 1)
-		channel_nr = frame_object->frame.channel;
+	const u8 channel_nr = gs_host_frame_object_get_channel_nr(frame_object);
 
 	return &hcan->channels[channel_nr];
 }

--- a/include/host_frame.h
+++ b/include/host_frame.h
@@ -29,9 +29,9 @@
 #include "config.h"
 #include "usbd_gs_can.h"
 
-static inline can_data_t
-*gs_host_frame_object_get_channel(USBD_GS_CAN_HandleTypeDef *hcan,
-								  struct gs_host_frame_object *frame_object)
+static inline can_data_t *
+gs_host_frame_object_get_channel(USBD_GS_CAN_HandleTypeDef *hcan,
+								 const struct gs_host_frame_object *frame_object)
 {
 	u8 channel_nr = 0;
 

--- a/include/list.h
+++ b/include/list.h
@@ -289,6 +289,15 @@ list_splice_tail_init(struct list_head *list, struct list_head *head)
 	INIT_LIST_HEAD(list);
 }
 
+static inline void
+list_splice_tail_init_locked(struct list_head *list, struct list_head *head)
+{
+	bool was_irq_enabled = disable_irq();
+
+	list_splice_tail_init(list, head);
+	restore_irq(was_irq_enabled);
+}
+
 #undef LIST_HEAD
 #define LIST_HEAD(name) struct list_head name = { &(name), &(name) }
 

--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -109,6 +109,9 @@ typedef struct {
 	bool dfu_detach_requested;
 } USBD_GS_CAN_HandleTypeDef __attribute__ ((aligned (4)));
 
+void usbd_gs_can_purge_to_host_list_by_channel(USBD_GS_CAN_HandleTypeDef *hcan,
+											   const struct can_channel *channel);
+
 #if defined(STM32F0)
 # define USB_INTERFACE USB
 # define USB_INTERRUPT USB_IRQn

--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -126,8 +126,8 @@ typedef struct {
 #endif
 
 uint8_t USBD_GS_CAN_Init(USBD_GS_CAN_HandleTypeDef *hcan, USBD_HandleTypeDef *pdev);
-void USBD_GS_CAN_SuspendCallback(USBD_HandleTypeDef  *pdev);
-void USBD_GS_CAN_ResumeCallback(USBD_HandleTypeDef  *pdev);
+void USBD_GS_CAN_SuspendCallback(USBD_HandleTypeDef *pdev);
+void USBD_GS_CAN_ResumeCallback(USBD_HandleTypeDef *pdev);
 void USBD_GS_CAN_ReceiveFromHost(USBD_HandleTypeDef *pdev);
 void USBD_GS_CAN_SendToHost(USBD_HandleTypeDef *pdev);
 bool USBD_GS_CAN_CustomDeviceRequest(USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef *req);

--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -26,6 +26,7 @@
 #include "board.h"
 #include "can.h"
 #include "can_common.h"
+#include "can_drv.h"
 #include "config.h"
 #include "device.h"
 #include "gs_usb.h"
@@ -146,7 +147,7 @@ static bool can_apply_filter(const can_data_t *channel)
 	return true;
 }
 
-void can_enable(can_data_t *channel)
+void can_drv_enable(struct can_channel *channel)
 {
 	const uint32_t feature = channel->feature;
 	CAN_TypeDef *can = channel->instance;
@@ -189,7 +190,7 @@ void can_enable(can_data_t *channel)
 	board_phy_power_set(channel, true);
 }
 
-void can_disable(can_data_t *channel)
+void can_drv_disable(struct can_channel *channel)
 {
 	CAN_TypeDef *can = channel->instance;
 

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -69,9 +69,10 @@ void can_enable(struct can_channel *channel, const uint32_t feature)
 	can_drv_enable(channel);
 }
 
-void can_disable(USBD_GS_CAN_HandleTypeDef __maybe_unused *hcan, struct can_channel *channel)
+void can_disable(USBD_GS_CAN_HandleTypeDef *hcan, struct can_channel *channel)
 {
 	can_drv_disable(channel);
+	usbd_gs_can_purge_to_host_list_by_channel(hcan, channel);
 	led_set_mode(&channel->leds, LED_MODE_OFF);
 }
 

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -1,28 +1,27 @@
 /*
-
-The MIT License (MIT)
-
-Copyright (c) 2016 Hubert Denkmair
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-*/
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Hubert Denkmair
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
 
 #include "can_common.h"
 #include "led.h"

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -24,6 +24,7 @@
  */
 
 #include "can_common.h"
+#include "can_drv.h"
 #include "led.h"
 #include "timer.h"
 #include "usbd_gs_can.h"
@@ -59,6 +60,20 @@ bool can_check_filter_ok(const struct gs_device_filter *filter)
 	return filter->info.dev == CAN_filter_info.dev;
 }
 #endif
+
+void can_enable(struct can_channel *channel, const uint32_t feature)
+{
+	channel->feature = feature;
+
+	led_set_mode(&channel->leds, LED_MODE_NORMAL);
+	can_drv_enable(channel);
+}
+
+void can_disable(USBD_GS_CAN_HandleTypeDef __maybe_unused *hcan, struct can_channel *channel)
+{
+	can_drv_disable(channel);
+	led_set_mode(&channel->leds, LED_MODE_OFF);
+}
 
 void CAN_SendFrame(USBD_GS_CAN_HandleTypeDef *hcan, can_data_t *channel)
 {

--- a/src/main.c
+++ b/src/main.c
@@ -78,7 +78,7 @@ int main(void)
 				 LEDTX_GPIO_Port, LEDTX_Pin, LEDTX_Active_High);
 
 		can_init(channel, channel_config);
-		can_disable(channel);
+		can_disable(&hGS_CAN, channel);
 	}
 
 	USBD_Init(&hUSB, (USBD_DescriptorsTypeDef *)&FS_Desc, DEVICE_FS);

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -264,6 +264,9 @@ static uint8_t USBD_GS_CAN_Start(USBD_HandleTypeDef *pdev, uint8_t __maybe_unuse
 
 static uint8_t USBD_GS_CAN_DeInit(USBD_HandleTypeDef *pdev, uint8_t __maybe_unused cfgidx)
 {
+	USBD_GS_CAN_HandleTypeDef *hcan = pdev->pClassData;
+
+	usbd_gs_can_purge_to_host_buf(hcan);
 	is_usb_suspend_cb = false;
 
 	USBD_LL_CloseEP(pdev, GSUSB_ENDPOINT_IN);

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -252,6 +252,8 @@ static uint8_t USBD_GS_CAN_Start(USBD_HandleTypeDef *pdev, uint8_t __maybe_unuse
 
 static uint8_t USBD_GS_CAN_DeInit(USBD_HandleTypeDef *pdev, uint8_t __maybe_unused cfgidx)
 {
+	is_usb_suspend_cb = false;
+
 	USBD_LL_CloseEP(pdev, GSUSB_ENDPOINT_IN);
 	USBD_LL_CloseEP(pdev, GSUSB_ENDPOINT_OUT);
 

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -551,14 +551,9 @@ static uint8_t USBD_GS_CAN_EP0_RxReady(USBD_HandleTypeDef *pdev) {
 			const struct gs_device_mode *mode = &ep0->mode;
 
 			if (mode->mode == GS_CAN_MODE_RESET) {
-				can_disable(channel);
-				led_set_mode(&channel->leds, LED_MODE_OFF);
+				can_disable(hcan, channel);
 			} else if (mode->mode == GS_CAN_MODE_START) {
-				channel->feature = mode->feature;
-
-				can_enable(channel);
-
-				led_set_mode(&channel->leds, LED_MODE_NORMAL);
+				can_enable(channel, mode->feature);
 			}
 			break;
 		}
@@ -932,8 +927,7 @@ void USBD_GS_CAN_SuspendCallback(USBD_HandleTypeDef *pdev)
 	for (unsigned int i = 0; i < ARRAY_SIZE(hcan->channels); i++) {
 		can_data_t *channel = &hcan->channels[i];
 
-		can_disable(channel);
-		led_set_mode(&channel->leds, LED_MODE_OFF);
+		can_disable(hcan, channel);
 	}
 
 	is_usb_suspend_cb = true;

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -905,9 +905,18 @@ void USBD_GS_CAN_SendToHost(USBD_HandleTypeDef *pdev)
 	if (result == USBD_OK)
 		return;
 
+	/*
+	 * If USBD_GS_CAN_SendFrame() fails, it will be due to a USB suspend event
+	 * (is_usb_suspend_cb == true).
+	 * For now the firmware shuts down the CAN interface during suspend and
+	 * hcan->to_host_buf is pruged by usbd_gs_can_purge_to_host_buf() during
+	 * USBD_GS_CAN_DeInit().
+	 */
 	was_irq_enabled = disable_irq();
-	list_add(&hcan->to_host_buf->list, &hcan->list_to_host);
-	hcan->to_host_buf = NULL;
+	if (hcan->to_host_buf) {
+		list_add_tail(&hcan->to_host_buf->list, &hcan->list_frame_pool);
+		hcan->to_host_buf = NULL;
+	}
 	restore_irq(was_irq_enabled);
 }
 

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -1,6 +1,7 @@
 /*
  * The MIT License (MIT)
  *
+ * Copyright (c) 2026 Marc Kleine-Budde <kernel@pengutronix.de>
  * Copyright (c) 2016 Hubert Denkmair
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -214,6 +215,35 @@ static const struct gs_device_config USBD_GS_CAN_dconf = {
 	.sw_version = 2,
 	.hw_version = 1,
 };
+
+void usbd_gs_can_purge_to_host_list_by_channel(USBD_GS_CAN_HandleTypeDef *hcan,
+											   const struct can_channel *channel)
+{
+	/*
+	 * If we only have one channel, all object of hcan->list_to_host belong to this one channel.
+	 * Move the complete list to the frame pool.
+	 */
+	if (NUM_CAN_CHANNEL == 1) {
+		list_splice_tail_init_locked(&hcan->list_to_host, &hcan->list_frame_pool);
+
+		return;
+	}
+
+	/*
+	 * For more than one channel, iterate over each object in hcan->list_to_host.
+	 */
+	struct gs_host_frame_object *iter, *next;
+	const u8 channel_nr = can_channel_get_nr(channel);
+	const bool was_irq_enabled = disable_irq();
+
+	list_for_each_entry_safe(iter, next, &hcan->list_to_host, list) {
+		if (gs_host_frame_object_get_channel_nr(iter) == channel_nr) {
+			list_move_tail(&iter->list, &hcan->list_frame_pool);
+		}
+	}
+
+	restore_irq(was_irq_enabled);
+}
 
 static void usbd_gs_can_purge_to_host_buf(USBD_GS_CAN_HandleTypeDef *hcan)
 {

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -215,6 +215,18 @@ static const struct gs_device_config USBD_GS_CAN_dconf = {
 	.hw_version = 1,
 };
 
+static void usbd_gs_can_purge_to_host_buf(USBD_GS_CAN_HandleTypeDef *hcan)
+{
+	bool was_irq_enabled = disable_irq();
+
+	if (hcan->to_host_buf) {
+		list_add_tail(&hcan->to_host_buf->list, &hcan->list_frame_pool);
+		hcan->to_host_buf = NULL;
+	}
+
+	restore_irq(was_irq_enabled);
+}
+
 /*
  * It's unclear from the documentation, but it appears that the USB library is
  * not safely reentrant. It attempts to signal errors via return values if it is

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -45,7 +45,7 @@
 #include "usbd_ioreq.h"
 #include "util.h"
 
-static volatile bool is_usb_suspend_cb = false;
+static volatile bool is_usb_suspend_cb;
 
 /* Configuration Descriptor */
 static const uint8_t USBD_GS_CAN_CfgDesc[USB_CAN_CONFIG_DESC_SIZ] =
@@ -136,7 +136,7 @@ static const uint8_t USBD_GS_CAN_WINUSB_STR[] =
 	0x00                     /* padding */
 };
 
-/*  Microsoft Compatible ID Feature Descriptor  */
+/* Microsoft Compatible ID Feature Descriptor */
 static const uint8_t USBD_MS_COMP_ID_FEATURE_DESC[] = {
 	0x40, 0x00, 0x00, 0x00, /* length */
 	0x00, 0x01,             /* version 1.0 */
@@ -215,18 +215,19 @@ static const struct gs_device_config USBD_GS_CAN_dconf = {
 	.hw_version = 1,
 };
 
-/* It's unclear from the documentation, but it appears that the USB library is
+/*
+ * It's unclear from the documentation, but it appears that the USB library is
  * not safely reentrant. It attempts to signal errors via return values if it is
  * reentered, but that code is not interrupt-safe and the error values are
  * silently ignored within the library in several cases. We'll just disable
  * interrupts at all entry points to be safe. Note that the callbacks are all
  * called from within the library itself, either within the interrupt handler or
  * within other calls, which means the USB interrupt is already disabled and we
- * don't have any other interrupts to worry about. */
-
+ * don't have any other interrupts to worry about.
+ */
 static inline uint8_t USBD_GS_CAN_PrepareReceive(USBD_HandleTypeDef *pdev)
 {
-	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*)pdev->pClassData;
+	USBD_GS_CAN_HandleTypeDef *hcan = pdev->pClassData;
 	struct gs_host_frame *frame = &hcan->from_host_buf[0]->frame;
 	uint16_t size;
 
@@ -239,23 +240,18 @@ static inline uint8_t USBD_GS_CAN_PrepareReceive(USBD_HandleTypeDef *pdev)
 	return USBD_LL_PrepareReceive(pdev, GSUSB_ENDPOINT_OUT, (uint8_t *)frame, size);
 }
 
-static uint8_t USBD_GS_CAN_Start(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
+static uint8_t USBD_GS_CAN_Start(USBD_HandleTypeDef *pdev, uint8_t __maybe_unused cfgidx)
 {
-	UNUSED(cfgidx);
-
 	assert_basic(pdev->pClassData);
 	USBD_LL_OpenEP(pdev, GSUSB_ENDPOINT_IN,	 USBD_EP_TYPE_BULK, CAN_DATA_MAX_PACKET_SIZE);
 	USBD_LL_OpenEP(pdev, GSUSB_ENDPOINT_OUT, USBD_EP_TYPE_BULK, CAN_DATA_MAX_PACKET_SIZE);
 	USBD_GS_CAN_PrepareReceive(pdev);
 
 	return USBD_OK;
-
 }
 
-static uint8_t USBD_GS_CAN_DeInit(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
+static uint8_t USBD_GS_CAN_DeInit(USBD_HandleTypeDef *pdev, uint8_t __maybe_unused cfgidx)
 {
-	UNUSED(cfgidx);
-
 	USBD_LL_CloseEP(pdev, GSUSB_ENDPOINT_IN);
 	USBD_LL_CloseEP(pdev, GSUSB_ENDPOINT_OUT);
 
@@ -303,7 +299,7 @@ static can_data_t *USBD_GS_CAN_GetChannel(USBD_GS_CAN_HandleTypeDef *hcan,
 
 static uint8_t USBD_GS_CAN_Config_Request(USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef *req)
 {
-	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*) pdev->pClassData;
+	USBD_GS_CAN_HandleTypeDef *hcan = pdev->pClassData;
 	union ep0 *ep0 = &hcan->ep0;
 	can_data_t *channel = NULL;
 	const void *src = NULL;
@@ -448,11 +444,9 @@ static uint8_t USBD_GS_CAN_Vendor_Request(USBD_HandleTypeDef *pdev, USBD_SetupRe
 	uint8_t req_rcpt = req->bmRequest & 0x1F;
 	uint8_t req_type = (req->bmRequest >> 5) & 0x03;
 
-	if (
-		(req_type == 0x01) // class request
-	   && (req_rcpt == 0x01) // recipient: interface
-	   && (req->wIndex == DFU_INTERFACE_NUM)
-		) {
+	if ((req_type == 0x01) &&   // class request
+		(req_rcpt == 0x01) &&   // recipient: interface
+		(req->wIndex == DFU_INTERFACE_NUM)) {
 		return USBD_GS_CAN_DFU_Request(pdev, req);
 	} else {
 		return USBD_GS_CAN_Config_Request(pdev, req);
@@ -464,7 +458,6 @@ static uint8_t USBD_GS_CAN_Setup(USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef 
 	static uint8_t ifalt = 0;
 
 	switch (req->bmRequest & USB_REQ_TYPE_MASK) {
-
 		case USB_REQ_TYPE_CLASS:
 		case USB_REQ_TYPE_VENDOR:
 			return USBD_GS_CAN_Vendor_Request(pdev, req);
@@ -480,10 +473,10 @@ static uint8_t USBD_GS_CAN_Setup(USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef 
 					break;
 			}
 			break;
-
 		default:
 			break;
 	}
+
 	return USBD_OK;
 }
 
@@ -495,7 +488,7 @@ static const led_seq_step_t led_identify_seq[] = {
 
 static uint8_t USBD_GS_CAN_EP0_RxReady(USBD_HandleTypeDef *pdev) {
 
-	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*) pdev->pClassData;
+	USBD_GS_CAN_HandleTypeDef *hcan = pdev->pClassData;
 	can_data_t *channel = NULL;
 	USBD_SetupReqTypedef *req = &hcan->last_setup_request;
 	const union ep0 *ep0 = &hcan->ep0;
@@ -534,7 +527,8 @@ static uint8_t USBD_GS_CAN_EP0_RxReady(USBD_HandleTypeDef *pdev) {
 
 	switch (req->bRequest) {
 		case GS_USB_BREQ_HOST_FORMAT:
-			/* The firmware on the original USB2CAN by Geschwister Schneider
+			/*
+			 * The firmware on the original USB2CAN by Geschwister Schneider
 			 * Technologie Entwicklungs- und Vertriebs UG exchanges all data
 			 * between the host and the device in host byte order. This is done
 			 * with the struct gs_host_config::byte_order member, which is sent
@@ -544,7 +538,6 @@ static uint8_t USBD_GS_CAN_EP0_RxReady(USBD_HandleTypeDef *pdev) {
 			 * this feature and exchanges the data in little endian byte order.
 			 */
 			break;
-
 		case GS_USB_BREQ_BITTIMING: {
 			const struct gs_device_bittiming *timing = &ep0->bittiming;
 
@@ -615,9 +608,8 @@ out_fail:
 	return USBD_FAIL;
 }
 
-static uint8_t USBD_GS_CAN_DataIn(USBD_HandleTypeDef *pdev, uint8_t epnum) {
-	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*)pdev->pClassData;
-	(void) epnum;
+static uint8_t USBD_GS_CAN_DataIn(USBD_HandleTypeDef *pdev, uint8_t __maybe_unused epnum) {
+	USBD_GS_CAN_HandleTypeDef *hcan = pdev->pClassData;
 
 	bool was_irq_enabled = disable_irq();
 	list_add_tail(&hcan->to_host_buf->list, &hcan->list_frame_pool);
@@ -658,11 +650,11 @@ static bool USBD_GS_Prefill_RX_Buffers(USBD_GS_CAN_HandleTypeDef *hcan)
 
 // Note that the return value is completely ignored by the stack.
 static uint8_t USBD_GS_CAN_DataOut(USBD_HandleTypeDef *pdev, uint8_t epnum) {
-	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*)pdev->pClassData;
+	USBD_GS_CAN_HandleTypeDef *hcan = pdev->pClassData;
 	can_data_t *channel;
 
 	/* If we do not have a valid incoming frame pointer, something broke. */
-	assert_basic (hcan->from_host_buf[0]);
+	assert_basic(hcan->from_host_buf[0]);
 
 	uint32_t rxlen = USBD_LL_GetRxDataSize(pdev, epnum);
 	if (rxlen < (struct_size(&hcan->from_host_buf[0]->frame, classic_can, 1))) {
@@ -708,7 +700,7 @@ static uint8_t USBD_GS_CAN_DataOut(USBD_HandleTypeDef *pdev, uint8_t epnum) {
 		// buffer, but disable further RX. If double buffer not in use,
 		// RX would have already been disabled by USB HW.
 		USBD_GS_CAN_PrepareReceive(pdev);
-		PCD_SET_EP_RX_STATUS(((PCD_HandleTypeDef*)pdev->pData)->Instance,
+		PCD_SET_EP_RX_STATUS(((PCD_HandleTypeDef *)pdev->pData)->Instance,
 							 GSUSB_ENDPOINT_OUT,
 							 USB_EP_RX_NAK);
 #endif
@@ -723,13 +715,16 @@ out_prepare_receive:
 			return USBD_OK;
 	}
 	USBD_GS_CAN_PrepareReceive(pdev);
+
 	return USBD_OK;
 }
 
 static uint8_t USBD_GS_CAN_SOF(struct _USBD_HandleTypeDef *pdev)
 {
-	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*) pdev->pClassData;
+	USBD_GS_CAN_HandleTypeDef *hcan = pdev->pClassData;
+
 	hcan->sof_timestamp_us = timer_get();
+
 	return USBD_OK;
 }
 
@@ -748,8 +743,6 @@ static uint8_t *USBD_GS_CAN_GetCfgDesc(uint16_t *len)
 
 uint8_t *USBD_GS_CAN_GetStrDesc(USBD_HandleTypeDef *pdev, uint8_t index, uint16_t *length)
 {
-	UNUSED(pdev);
-
 	switch (index) {
 		case DFU_INTERFACE_STR_INDEX:
 			USBD_GetString((uint8_t *)DFU_INTERFACE_STRING_FS, USBD_DescBuf, length);
@@ -791,26 +784,21 @@ uint8_t USBD_GS_CAN_Init(USBD_GS_CAN_HandleTypeDef *hcan, USBD_HandleTypeDef *pd
 bool USBD_GS_CAN_CustomDeviceRequest(USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef *req)
 {
 	if (req->bRequest == USBD_GS_CAN_VENDOR_CODE) {
-
 		switch (req->wIndex) {
-
 			case 0x0004:
 				memcpy(USBD_DescBuf, USBD_MS_COMP_ID_FEATURE_DESC, sizeof(USBD_MS_COMP_ID_FEATURE_DESC));
 				BUILD_BUG_ON(sizeof(USBD_MS_COMP_ID_FEATURE_DESC) >= sizeof(USBD_DescBuf));
 				USBD_CtlSendData(pdev, USBD_DescBuf, MIN(sizeof(USBD_MS_COMP_ID_FEATURE_DESC), req->wLength));
 				return true;
-
 			case 0x0005:
-				if (req->wValue==0) { // only return our GUID for interface #0
+				if (req->wValue == 0) { // only return our GUID for interface #0
 					memcpy(USBD_DescBuf, USBD_MS_EXT_PROP_FEATURE_DESC, sizeof(USBD_MS_EXT_PROP_FEATURE_DESC));
 					BUILD_BUG_ON(sizeof(USBD_MS_EXT_PROP_FEATURE_DESC) >= sizeof(USBD_DescBuf));
 					USBD_CtlSendData(pdev, USBD_DescBuf, MIN(sizeof(USBD_MS_EXT_PROP_FEATURE_DESC), req->wLength));
 					return true;
 				}
 				break;
-
 		}
-
 	}
 
 	return false;
@@ -823,7 +811,7 @@ bool USBD_GS_CAN_CustomInterfaceRequest(USBD_HandleTypeDef *pdev, USBD_SetupReqT
 
 void USBD_GS_CAN_ReceiveFromHost(USBD_HandleTypeDef *pdev)
 {
-	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*)pdev->pClassData;
+	USBD_GS_CAN_HandleTypeDef *hcan = pdev->pClassData;
 
 	bool was_irq_enabled = disable_irq();
 
@@ -850,7 +838,7 @@ static uint8_t USBD_GS_CAN_Transmit(USBD_HandleTypeDef *pdev, uint8_t *buf, uint
 static uint8_t USBD_GS_CAN_SendFrame(USBD_HandleTypeDef *pdev,
 									 struct gs_host_frame_object *frame_object)
 {
-	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*)pdev->pClassData;
+	USBD_GS_CAN_HandleTypeDef *hcan = pdev->pClassData;
 	const can_data_t *channel = gs_host_frame_object_get_channel(hcan, frame_object);
 	const struct gs_host_frame *frame = &frame_object->frame;
 	uint8_t buf[CAN_DATA_MAX_PACKET_SIZE];
@@ -899,7 +887,7 @@ static uint8_t USBD_GS_CAN_SendFrame(USBD_HandleTypeDef *pdev,
 
 void USBD_GS_CAN_SendToHost(USBD_HandleTypeDef *pdev)
 {
-	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*)pdev->pClassData;
+	USBD_GS_CAN_HandleTypeDef *hcan = pdev->pClassData;
 
 	bool was_irq_enabled = disable_irq();
 	if (hcan->to_host_buf) {
@@ -930,15 +918,16 @@ void USBD_GS_CAN_SendToHost(USBD_HandleTypeDef *pdev)
 
 bool USBD_GS_CAN_DfuDetachRequested(USBD_HandleTypeDef *pdev)
 {
-	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*)pdev->pClassData;
+	USBD_GS_CAN_HandleTypeDef *hcan = pdev->pClassData;
+
 	return hcan->dfu_detach_requested;
 }
 
 // Handle USB suspend event
-void USBD_GS_CAN_SuspendCallback(USBD_HandleTypeDef  *pdev)
+void USBD_GS_CAN_SuspendCallback(USBD_HandleTypeDef *pdev)
 {
 	// Disable CAN and go off bus on USB suspend
-	USBD_GS_CAN_HandleTypeDef *hcan = (USBD_GS_CAN_HandleTypeDef*) pdev->pClassData;
+	USBD_GS_CAN_HandleTypeDef *hcan = pdev->pClassData;
 
 	for (unsigned int i = 0; i < ARRAY_SIZE(hcan->channels); i++) {
 		can_data_t *channel = &hcan->channels[i];
@@ -950,8 +939,7 @@ void USBD_GS_CAN_SuspendCallback(USBD_HandleTypeDef  *pdev)
 	is_usb_suspend_cb = true;
 }
 
-void USBD_GS_CAN_ResumeCallback(USBD_HandleTypeDef  *pdev)
+void USBD_GS_CAN_ResumeCallback(USBD_HandleTypeDef __maybe_unused *pdev)
 {
-	(void)pdev;
 	is_usb_suspend_cb = false;
 }


### PR DESCRIPTION
This PR fixes problems when the USB host suspends or reboots without proper shutdown of CAN interface while ongoing USB IN (device -> host) transfers.

The USB IN transfer might not complete and `hGS_CAN.to_host_buf` will stay set and  `USBD_GS_CAN_SendToHost()` will not send further USB IN packets.

Fix the problem by purging the `hGS_CAN.to_host_buf` and `hGS_CAN.list_to_host`.

Closes: https://github.com/candle-usb/candleLight_fw/issues/225
Closes: https://github.com/candle-usb/candleLight_fw/issues/266
Supersedes: https://github.com/candle-usb/candleLight_fw/pull/267