### PR TITLE
improve CAN error handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,6 +209,7 @@ set(
 	include/device.h
 	include/dfu.h src/dfu.c
 	include/gpio.h src/gpio.c
+	include/host_frame.h
 	include/led.h src/led.c
 	include/timer.h src/timer.c
 	include/util.h src/util.c

--- a/include/can.h
+++ b/include/can.h
@@ -89,15 +89,3 @@ bool can_receive(can_data_t *channel, struct gs_host_frame *rx_frame);
 bool can_is_rx_pending(can_data_t *channel);
 
 bool can_send(can_data_t *channel, struct gs_host_frame *frame);
-
-/** return CAN->ESR register which contains tx/rx error counters and
- * LEC (last error code).
- */
-uint32_t can_get_error_status(can_data_t *channel);
-
-/** parse status value returned by can_get_error_status().
- * @param frame : will hold the generated error frame
- * @param err : holds the contents of the ESR register
- * @return 1 when status changes (if any) need a new error frame sent
- */
-bool can_parse_error_status(can_data_t *channel, struct gs_host_frame *frame, uint32_t err);

--- a/include/can.h
+++ b/include/can.h
@@ -41,7 +41,7 @@ typedef struct can_channel {
 	struct list_head list_from_host;
 	led_data_t leds;
 	uint32_t feature;
-	uint32_t reg_esr_old;
+	enum gs_can_state state;
 #if defined (CONFIG_BXCAN)
 	struct gs_device_filter filter;
 	uint32_t btr;

--- a/include/can_common.h
+++ b/include/can_common.h
@@ -1,6 +1,7 @@
 /*
  * The MIT License (MIT)
  *
+ * Copyright (c) 2026 Marc Kleine-Budde <kernel@pengutronix.de>
  * Copyright (c) 2016 Hubert Denkmair
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -66,6 +67,9 @@ static inline u8 can_channel_get_nr(const can_data_t __maybe_unused *channel)
 
 void can_enable(struct can_channel *channel, uint32_t mode);
 void can_disable(USBD_GS_CAN_HandleTypeDef *hcan, struct can_channel *channel);
+enum gs_can_state can_err_to_state(const uint16_t err);
+u8 gs_can_tx_state_to_frame(const enum gs_can_state state);
+u8 gs_can_rx_state_to_frame(const enum gs_can_state state);
 
 void CAN_SendFrame(USBD_GS_CAN_HandleTypeDef *hcan, can_data_t *channel);
 void CAN_ReceiveFrame(USBD_GS_CAN_HandleTypeDef *hcan, can_data_t *channel);

--- a/include/can_drv.h
+++ b/include/can_drv.h
@@ -28,6 +28,7 @@
 #include <stdbool.h>
 
 struct can_channel;
+struct gs_device_state;
 struct gs_host_frame;
 
 void can_drv_enable(struct can_channel *channel);
@@ -35,6 +36,7 @@ void can_drv_disable(struct can_channel *channel);
 
 enum gs_can_state can_drv_get_state(const struct can_channel *channel);
 void can_drv_handle_state_change(const struct can_channel *channel, struct gs_host_frame *frame);
+void can_drv_get_device_state(const struct can_channel *channel, struct gs_device_state *state);
 
 bool can_drv_bus_error_pending(const struct can_channel *channel);
 void can_drv_handle_bus_error(const struct can_channel *channel, struct gs_host_frame *frame);

--- a/include/can_drv.h
+++ b/include/can_drv.h
@@ -25,7 +25,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <stdbool.h>
 
 struct can_channel;
 struct gs_host_frame;
@@ -35,3 +35,6 @@ void can_drv_disable(struct can_channel *channel);
 
 enum gs_can_state can_drv_get_state(const struct can_channel *channel);
 void can_drv_handle_state_change(const struct can_channel *channel, struct gs_host_frame *frame);
+
+bool can_drv_bus_error_pending(const struct can_channel *channel);
+void can_drv_handle_bus_error(const struct can_channel *channel, struct gs_host_frame *frame);

--- a/include/can_drv.h
+++ b/include/can_drv.h
@@ -28,6 +28,10 @@
 #include <stdint.h>
 
 struct can_channel;
+struct gs_host_frame;
 
 void can_drv_enable(struct can_channel *channel);
 void can_drv_disable(struct can_channel *channel);
+
+enum gs_can_state can_drv_get_state(const struct can_channel *channel);
+void can_drv_handle_state_change(const struct can_channel *channel, struct gs_host_frame *frame);

--- a/include/gs_usb.h
+++ b/include/gs_usb.h
@@ -1,28 +1,27 @@
 /*
-
-The MIT License (MIT)
-
-Copyright (c) 2016 Hubert Denkmair
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-*/
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 Hubert Denkmair
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
 
 #pragma once
 

--- a/include/gs_usb.h
+++ b/include/gs_usb.h
@@ -328,6 +328,8 @@ struct canfd_ts {
 	u32 timestamp_us;
 } __packed __aligned(4);
 
+#define GS_HOST_FRAME_ECHO_ID_RX 0xffffffff
+
 struct gs_host_frame {
 	u32 echo_id;
 	u32 can_id;

--- a/include/gs_usb.h
+++ b/include/gs_usb.h
@@ -92,6 +92,8 @@
 #define CAN_ERR_BUSOFF	   0x00000040U   /* bus off */
 #define CAN_ERR_BUSERROR   0x00000080U   /* bus error (may flood!) */
 #define CAN_ERR_RESTARTED  0x00000100U   /* controller restarted */
+#define CAN_ERR_CNT		   0x00000200U   /* TX error counter / data[6] */
+                                         /* RX error counter / data[7] */
 
 /* arbitration lost in bit ... / data[0] */
 #define CAN_ERR_LOSTARB_UNSPEC 0x00   /* unspecified */

--- a/include/host_frame.h
+++ b/include/host_frame.h
@@ -46,3 +46,24 @@ gs_host_frame_object_get_channel(USBD_GS_CAN_HandleTypeDef *hcan,
 
 	return &hcan->channels[channel_nr];
 }
+
+static inline
+struct gs_host_frame_object *
+gs_host_frame_object_get_locked(USBD_GS_CAN_HandleTypeDef *hcan)
+{
+	struct gs_host_frame_object *frame_object;
+
+	bool was_irq_enabled = disable_irq();
+	frame_object = list_first_entry_or_null(&hcan->list_frame_pool,
+											struct gs_host_frame_object,
+											list);
+	if (!frame_object) {
+		restore_irq(was_irq_enabled);
+		return NULL;
+	}
+
+	list_del(&frame_object->list);
+	restore_irq(was_irq_enabled);
+
+	return frame_object;
+}

--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -78,6 +78,7 @@ typedef struct {
 		struct_group_tagged(ep0_data, data, union {
 			// Device -> Host
 			struct dfu_status dfu_status;
+			struct gs_device_state state;
 
 			// Host -> Device
 			const struct gs_host_config config;

--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -52,9 +52,8 @@ const struct gs_device_bt_const CAN_btconst = {
 		GS_CAN_FEATURE_PAD_PKTS_TO_MAX_PKT_SIZE |
 		(IS_ENABLED(CONFIG_TERMINATION) ?
 		 GS_CAN_FEATURE_TERMINATION : 0) |
-#ifdef CONFIG_CAN_FILTER
-		GS_CAN_FEATURE_FILTER |
-#endif
+		(IS_ENABLED(CONFIG_CAN_FILTER) ?
+		 GS_CAN_FEATURE_FILTER : 0) |
 		0,
 	.fclk_can = CAN_CLOCK_SPEED,
 	.btc = {

--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -360,81 +360,46 @@ void can_drv_handle_state_change(const struct can_channel *channel, struct gs_ho
 	frame->classic_can->data[7] = rx_err;
 }
 
-uint32_t can_get_error_status(can_data_t *channel)
+bool can_drv_bus_error_pending(const struct can_channel *channel)
 {
-	CAN_TypeDef *can = channel->instance;
-	uint32_t err = can->ESR;
+	const uint32_t reg_esr = channel->instance->ESR;
+	const uint32_t lec = FIELD_GET(CAN_ESR_LEC, reg_esr);
 
-	/* Write 7 to LEC so we know if it gets set to the same thing again */
-	can->ESR = 7 << 4;
-
-	return err;
+	return lec != BXCAN_LEC_NO_ERROR && lec != BXCAN_LEC_SOFTWARE;
 }
 
-bool can_parse_error_status(can_data_t __maybe_unused *channel, struct gs_host_frame *frame, uint32_t err)
+void can_drv_handle_bus_error(const struct can_channel *channel, struct gs_host_frame *frame)
 {
-	/*
-	 * We build up the detailed error information at the same time as we decide
-	 * whether there's anything worth sending. This variable tracks that final
-	 * result.
-	 */
-	bool should_send = false;
+	const uint32_t reg_esr = channel->instance->ESR;
+	const uint32_t lec = FIELD_GET(CAN_ESR_LEC, reg_esr);
 
-	frame->echo_id = 0xFFFFFFFF;
-	frame->can_id  = CAN_ERR_FLAG;
-	frame->can_dlc = CAN_ERR_DLC;
-	frame->classic_can->data[0] = CAN_ERR_LOSTARB_UNSPEC;
-	frame->classic_can->data[1] = CAN_ERR_CRTL_UNSPEC;
-	frame->classic_can->data[2] = CAN_ERR_PROT_UNSPEC;
-	frame->classic_can->data[3] = CAN_ERR_PROT_LOC_UNSPEC;
-	frame->classic_can->data[4] = CAN_ERR_TRX_UNSPEC;
-	frame->classic_can->data[5] = 0;
-	frame->classic_can->data[6] = 0;
-	frame->classic_can->data[7] = 0;
+	frame->can_id |= CAN_ERR_PROT | CAN_ERR_BUSERROR | CAN_ERR_CNT;
+	frame->classic_can->data[6] = FIELD_GET(CAN_ESR_TEC, reg_esr);
+	frame->classic_can->data[7] = FIELD_GET(CAN_ESR_REC, reg_esr);
 
-	uint8_t tx_error_cnt = (err >> 16) & 0xFF;
-	uint8_t rx_error_cnt = (err >> 24) & 0xFF;
-	/*
-	 * The Linux sja1000 driver puts these counters here. Seems like as good a
-	 * place as any.
-	 */
-	frame->classic_can->data[6] = tx_error_cnt;
-	frame->classic_can->data[7] = rx_error_cnt;
-
-	uint8_t lec = (err>>4) & 0x07;
 	switch (lec) {
 		case BXCAN_LEC_STUFF_ERROR:
-			frame->can_id |= CAN_ERR_PROT;
 			frame->classic_can->data[2] |= CAN_ERR_PROT_STUFF;
-			should_send = true;
 			break;
 		case BXCAN_LEC_FORM_ERROR:
-			frame->can_id |= CAN_ERR_PROT;
 			frame->classic_can->data[2] |= CAN_ERR_PROT_FORM;
-			should_send = true;
 			break;
 		case BXCAN_LEC_ACK_ERROR:
 			frame->can_id |= CAN_ERR_ACK;
-			should_send = true;
 			break;
 		case BXCAN_LEC_REC_ERROR:
-			frame->can_id |= CAN_ERR_PROT;
 			frame->classic_can->data[2] |= CAN_ERR_PROT_BIT1;
-			should_send = true;
 			break;
 		case BXCAN_LEC_DOM_ERROR:
-			frame->can_id |= CAN_ERR_PROT;
 			frame->classic_can->data[2] |= CAN_ERR_PROT_BIT0;
-			should_send = true;
 			break;
 		case BXCAN_LEC_CRC_ERROR:
-			frame->can_id |= CAN_ERR_PROT;
 			frame->classic_can->data[3] |= CAN_ERR_PROT_LOC_CRC_SEQ;
-			should_send = true;
 			break;
 		default:
 			break;
 	}
 
-	return should_send;
+	/* mark as handled by software */
+	channel->instance->ESR |= FIELD_PREP(CAN_ESR_LEC, BXCAN_LEC_SOFTWARE);
 }

--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -52,6 +52,7 @@ const struct gs_device_bt_const CAN_btconst = {
 		GS_CAN_FEATURE_PAD_PKTS_TO_MAX_PKT_SIZE |
 		(IS_ENABLED(CONFIG_TERMINATION) ?
 		 GS_CAN_FEATURE_TERMINATION : 0) |
+		GS_CAN_FEATURE_BERR_REPORTING |
 		(IS_ENABLED(CONFIG_CAN_FILTER) ?
 		 GS_CAN_FEATURE_FILTER : 0) |
 		0,
@@ -363,6 +364,10 @@ bool can_drv_bus_error_pending(const struct can_channel *channel)
 {
 	const uint32_t reg_esr = channel->instance->ESR;
 	const uint32_t lec = FIELD_GET(CAN_ESR_LEC, reg_esr);
+
+	if (!(channel->feature & GS_CAN_FEATURE_BERR_REPORTING)) {
+		false;
+	}
 
 	return lec != BXCAN_LEC_NO_ERROR && lec != BXCAN_LEC_SOFTWARE;
 }

--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -1,6 +1,7 @@
 /*
  * The MIT License (MIT)
  *
+ * Copyright (c) 2026 Marc Kleine-Budde <kernel@pengutronix.de>
  * Copyright (c) 2016 Hubert Denkmair
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -310,6 +311,46 @@ bool can_send(can_data_t *channel, struct gs_host_frame *frame)
 	}
 }
 
+enum gs_can_state can_drv_get_state(const struct can_channel *channel)
+{
+	const uint32_t reg_esr = channel->instance->ESR;
+
+	if (!(reg_esr & (CAN_ESR_BOFF | CAN_ESR_EPVF | CAN_ESR_EWGF))) {
+		return GS_CAN_STATE_ERROR_ACTIVE;
+	}
+
+	if (reg_esr & CAN_ESR_BOFF) {
+		return GS_CAN_STATE_BUS_OFF;
+	}
+
+	if (reg_esr & CAN_ESR_EPVF) {
+		return GS_CAN_STATE_ERROR_PASSIVE;
+	}
+
+	return GS_CAN_STATE_ERROR_WARNING;
+}
+
+void can_drv_handle_state_change(const struct can_channel *channel, struct gs_host_frame *frame)
+{
+	const uint32_t reg_esr = channel->instance->ESR;
+	enum gs_can_state tx_state, rx_state;
+	u8 tx_err, rx_err;
+
+	tx_err = FIELD_GET(CAN_ESR_TEC, reg_esr);
+	rx_err = FIELD_GET(CAN_ESR_REC, reg_esr);
+
+	tx_state = can_err_to_state(tx_err);
+	rx_state = can_err_to_state(rx_err);
+
+	if (tx_state >= rx_state)
+		frame->classic_can->data[1] |= gs_can_tx_state_to_frame(tx_state);
+	if (tx_state <= rx_state)
+		frame->classic_can->data[1] |= gs_can_rx_state_to_frame(rx_state);
+
+	frame->classic_can->data[6] = tx_err;
+	frame->classic_can->data[7] = rx_err;
+}
+
 uint32_t can_get_error_status(can_data_t *channel)
 {
 	CAN_TypeDef *can = channel->instance;
@@ -321,22 +362,14 @@ uint32_t can_get_error_status(can_data_t *channel)
 	return err;
 }
 
-static bool status_is_active(uint32_t err)
+bool can_parse_error_status(can_data_t __maybe_unused *channel, struct gs_host_frame *frame, uint32_t err)
 {
-	return !(err & (CAN_ESR_BOFF | CAN_ESR_EPVF));
-}
-
-bool can_parse_error_status(can_data_t *channel, struct gs_host_frame *frame, uint32_t err)
-{
-	uint32_t last_err = channel->reg_esr_old;
 	/*
 	 * We build up the detailed error information at the same time as we decide
 	 * whether there's anything worth sending. This variable tracks that final
 	 * result.
 	 */
 	bool should_send = false;
-
-	channel->reg_esr_old = err;
 
 	frame->echo_id = 0xFFFFFFFF;
 	frame->can_id  = CAN_ERR_FLAG;
@@ -350,28 +383,6 @@ bool can_parse_error_status(can_data_t *channel, struct gs_host_frame *frame, ui
 	frame->classic_can->data[6] = 0;
 	frame->classic_can->data[7] = 0;
 
-	if (err & CAN_ESR_BOFF) {
-		if (!(last_err & CAN_ESR_BOFF)) {
-			/* We transitioned to bus-off. */
-			frame->can_id |= CAN_ERR_BUSOFF;
-			should_send = true;
-		}
-		// - tec (overflowed) / rec (looping, likely used for recessive counting)
-		//   are not valid in the bus-off state.
-		// - The warning flags remains set, error passive will cleared.
-		// - LEC errors will be reported, while the device isn't even allowed to send.
-		//
-		// Hence only report bus-off, ignore everything else.
-		return should_send;
-	}
-
-	/* We transitioned from passive/bus-off to active, so report the edge. */
-	if (!status_is_active(last_err) && status_is_active(err)) {
-		frame->can_id |= CAN_ERR_CRTL;
-		frame->classic_can->data[1] |= CAN_ERR_CRTL_ACTIVE;
-		should_send = true;
-	}
-
 	uint8_t tx_error_cnt = (err >> 16) & 0xFF;
 	uint8_t rx_error_cnt = (err >> 24) & 0xFF;
 	/*
@@ -380,20 +391,6 @@ bool can_parse_error_status(can_data_t *channel, struct gs_host_frame *frame, ui
 	 */
 	frame->classic_can->data[6] = tx_error_cnt;
 	frame->classic_can->data[7] = rx_error_cnt;
-
-	if (err & CAN_ESR_EPVF) {
-		if (!(last_err & CAN_ESR_EPVF)) {
-			frame->can_id |= CAN_ERR_CRTL;
-			frame->classic_can->data[1] |= CAN_ERR_CRTL_RX_PASSIVE | CAN_ERR_CRTL_TX_PASSIVE;
-			should_send = true;
-		}
-	} else if (err & CAN_ESR_EWGF) {
-		if (!(last_err & CAN_ESR_EWGF)) {
-			frame->can_id |= CAN_ERR_CRTL;
-			frame->classic_can->data[1] |= CAN_ERR_CRTL_RX_WARNING | CAN_ERR_CRTL_TX_WARNING;
-			should_send = true;
-		}
-	}
 
 	uint8_t lec = (err>>4) & 0x07;
 	switch (lec) {

--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -33,6 +33,15 @@
 #include "gs_usb.h"
 #include "timer.h"
 
+#define BXCAN_LEC_NO_ERROR	  0
+#define BXCAN_LEC_STUFF_ERROR 1
+#define BXCAN_LEC_FORM_ERROR  2
+#define BXCAN_LEC_ACK_ERROR	  3
+#define BXCAN_LEC_REC_ERROR	  4
+#define BXCAN_LEC_DOM_ERROR	  5
+#define BXCAN_LEC_CRC_ERROR	  6
+#define BXCAN_LEC_SOFTWARE	  7
+
 const struct gs_device_bt_const CAN_btconst = {
 	.feature =
 		GS_CAN_FEATURE_LISTEN_ONLY |
@@ -394,36 +403,36 @@ bool can_parse_error_status(can_data_t __maybe_unused *channel, struct gs_host_f
 
 	uint8_t lec = (err>>4) & 0x07;
 	switch (lec) {
-		case 0x01: /* stuff error */
+		case BXCAN_LEC_STUFF_ERROR:
 			frame->can_id |= CAN_ERR_PROT;
 			frame->classic_can->data[2] |= CAN_ERR_PROT_STUFF;
 			should_send = true;
 			break;
-		case 0x02: /* form error */
+		case BXCAN_LEC_FORM_ERROR:
 			frame->can_id |= CAN_ERR_PROT;
 			frame->classic_can->data[2] |= CAN_ERR_PROT_FORM;
 			should_send = true;
 			break;
-		case 0x03: /* ack error */
+		case BXCAN_LEC_ACK_ERROR:
 			frame->can_id |= CAN_ERR_ACK;
 			should_send = true;
 			break;
-		case 0x04: /* bit recessive error */
+		case BXCAN_LEC_REC_ERROR:
 			frame->can_id |= CAN_ERR_PROT;
 			frame->classic_can->data[2] |= CAN_ERR_PROT_BIT1;
 			should_send = true;
 			break;
-		case 0x05: /* bit dominant error */
+		case BXCAN_LEC_DOM_ERROR:
 			frame->can_id |= CAN_ERR_PROT;
 			frame->classic_can->data[2] |= CAN_ERR_PROT_BIT0;
 			should_send = true;
 			break;
-		case 0x06: /* CRC error */
+		case BXCAN_LEC_CRC_ERROR:
 			frame->can_id |= CAN_ERR_PROT;
 			frame->classic_can->data[3] |= CAN_ERR_PROT_LOC_CRC_SEQ;
 			should_send = true;
 			break;
-		default: /* 0=no error, 7=no change */
+		default:
 			break;
 	}
 

--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -53,6 +53,7 @@ const struct gs_device_bt_const CAN_btconst = {
 		(IS_ENABLED(CONFIG_TERMINATION) ?
 		 GS_CAN_FEATURE_TERMINATION : 0) |
 		GS_CAN_FEATURE_BERR_REPORTING |
+		GS_CAN_FEATURE_GET_STATE |
 		(IS_ENABLED(CONFIG_CAN_FILTER) ?
 		 GS_CAN_FEATURE_FILTER : 0) |
 		0,
@@ -358,6 +359,15 @@ void can_drv_handle_state_change(const struct can_channel *channel, struct gs_ho
 
 	frame->classic_can->data[6] = tx_err;
 	frame->classic_can->data[7] = rx_err;
+}
+
+void can_drv_get_device_state(const struct can_channel *channel, struct gs_device_state *state)
+{
+	const uint32_t reg_esr = channel->instance->ESR;
+
+	state->state = can_drv_get_state(channel);
+	state->rxerr = FIELD_GET(CAN_ESR_REC, reg_esr);
+	state->txerr = FIELD_GET(CAN_ESR_TEC, reg_esr);
 }
 
 bool can_drv_bus_error_pending(const struct can_channel *channel)

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -232,41 +232,33 @@ void can_handle_state_change(USBD_GS_CAN_HandleTypeDef *hcan, struct can_channel
 	list_add_tail_locked(&frame_object->list, &hcan->list_to_host);
 }
 
+void can_handle_bus_error(USBD_GS_CAN_HandleTypeDef *hcan, struct can_channel *channel)
+{
+	if (!can_drv_bus_error_pending(channel))
+		return;
+
+	struct gs_host_frame_object *frame_object = gs_host_frame_object_get_locked(hcan);
+	if (!frame_object)
+		return;
+
+	struct gs_host_frame *frame = &frame_object->frame;
+
+	can_prepare_error_frame(channel, frame);
+	can_drv_handle_bus_error(channel, frame);
+
+	list_add_tail_locked(&frame_object->list, &hcan->list_to_host);
+}
+
 // If there are frames to receive, don't report any error frames. The
 // best we can localize the errors to is "after the last successfully
 // received frame", so wait until we get there. LEC will hold some error
 // to report even if multiple pass by.
 void CAN_HandleError(USBD_GS_CAN_HandleTypeDef *hcan, can_data_t *channel)
 {
-	struct gs_host_frame_object *frame_object;
-
 	if (can_is_rx_pending(channel)) {
 		return;
 	}
 
-	uint32_t can_err = can_get_error_status(channel);
-
-	bool was_irq_enabled = disable_irq();
-	frame_object = list_first_entry_or_null(&hcan->list_frame_pool,
-											struct gs_host_frame_object,
-											list);
-	if (!frame_object) {
-		restore_irq(was_irq_enabled);
-		return;
-	}
-
-	list_del(&frame_object->list);
-	restore_irq(was_irq_enabled);
-
-	struct gs_host_frame *frame = &frame_object->frame;
-	frame->classic_can_ts->timestamp_us = timer_get();
-	frame->channel = can_channel_get_nr(channel);
-
-	if (can_parse_error_status(channel, frame, can_err)) {
-		list_add_tail_locked(&frame_object->list, &hcan->list_to_host);
-	} else {
-		list_add_tail_locked(&frame_object->list, &hcan->list_frame_pool);
-	}
-
+	can_handle_bus_error(hcan, channel);
 	can_handle_state_change(hcan, channel);
 }

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -25,6 +25,7 @@
 
 #include "can_common.h"
 #include "can_drv.h"
+#include "host_frame.h"
 #include "led.h"
 #include "timer.h"
 #include "usbd_gs_can.h"
@@ -119,17 +120,10 @@ void CAN_ReceiveFrame(USBD_GS_CAN_HandleTypeDef *hcan, can_data_t *channel)
 		return;
 	}
 
-	bool was_irq_enabled = disable_irq();
-	frame_object = list_first_entry_or_null(&hcan->list_frame_pool,
-											struct gs_host_frame_object,
-											list);
+	frame_object = gs_host_frame_object_get_locked(hcan);
 	if (!frame_object) {
-		restore_irq(was_irq_enabled);
 		return;
 	}
-
-	list_del(&frame_object->list);
-	restore_irq(was_irq_enabled);
 
 	struct gs_host_frame *frame = &frame_object->frame;
 

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -1,6 +1,7 @@
 /*
  * The MIT License (MIT)
  *
+ * Copyright (c) 2026 Marc Kleine-Budde <kernel@pengutronix.de>
  * Copyright (c) 2016 Hubert Denkmair
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -29,6 +30,10 @@
 #include "led.h"
 #include "timer.h"
 #include "usbd_gs_can.h"
+
+#define CAN_ERROR_WARNING_THRESHOLD 96
+#define CAN_ERROR_PASSIVE_THRESHOLD 128
+#define CAN_BUS_OFF_THRESHOLD		256
 
 #ifndef CONFIG_CANFD
 const struct gs_device_bt_const_extended CAN_btconst_ext;
@@ -138,6 +143,46 @@ void CAN_ReceiveFrame(USBD_GS_CAN_HandleTypeDef *hcan, can_data_t *channel)
 	list_add_tail_locked(&frame_object->list, &hcan->list_to_host);
 
 	led_indicate_trx(&channel->leds, LED_RX);
+}
+
+enum gs_can_state can_err_to_state(const uint16_t err)
+{
+	if (err < CAN_ERROR_WARNING_THRESHOLD)
+		return GS_CAN_STATE_ERROR_ACTIVE;
+	if (err < CAN_ERROR_PASSIVE_THRESHOLD)
+		return GS_CAN_STATE_ERROR_WARNING;
+	if (err < CAN_BUS_OFF_THRESHOLD)
+		return GS_CAN_STATE_ERROR_PASSIVE;
+
+	return GS_CAN_STATE_BUS_OFF;
+}
+
+u8 gs_can_tx_state_to_frame(const enum gs_can_state state)
+{
+	switch (state) {
+		case GS_CAN_STATE_ERROR_ACTIVE:
+			return CAN_ERR_CRTL_ACTIVE;
+		case GS_CAN_STATE_ERROR_WARNING:
+			return CAN_ERR_CRTL_TX_WARNING;
+		case GS_CAN_STATE_ERROR_PASSIVE:
+			return CAN_ERR_CRTL_TX_PASSIVE;
+		default:
+			return 0;
+	}
+}
+
+u8 gs_can_rx_state_to_frame(const enum gs_can_state state)
+{
+	switch (state) {
+		case GS_CAN_STATE_ERROR_ACTIVE:
+			return CAN_ERR_CRTL_ACTIVE;
+		case GS_CAN_STATE_ERROR_WARNING:
+			return CAN_ERR_CRTL_RX_WARNING;
+		case GS_CAN_STATE_ERROR_PASSIVE:
+			return CAN_ERR_CRTL_RX_PASSIVE;
+		default:
+			return 0;
+	}
 }
 
 // If there are frames to receive, don't report any error frames. The

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -74,6 +74,7 @@ void can_enable(struct can_channel *channel, const uint32_t feature)
 	channel->feature = feature;
 
 	led_set_mode(&channel->leds, LED_MODE_NORMAL);
+	channel->state = GS_CAN_STATE_ERROR_ACTIVE;
 	can_drv_enable(channel);
 }
 
@@ -81,6 +82,7 @@ void can_disable(USBD_GS_CAN_HandleTypeDef *hcan, struct can_channel *channel)
 {
 	can_drv_disable(channel);
 	usbd_gs_can_purge_to_host_list_by_channel(hcan, channel);
+	channel->state = GS_CAN_STATE_STOPPED;
 	led_set_mode(&channel->leds, LED_MODE_OFF);
 }
 
@@ -202,6 +204,34 @@ u8 gs_can_rx_state_to_frame(const enum gs_can_state state)
 	}
 }
 
+void can_handle_state_change(USBD_GS_CAN_HandleTypeDef *hcan, struct can_channel *channel)
+{
+	enum gs_can_state new_state;
+
+	new_state = can_drv_get_state(channel);
+
+	if (new_state == channel->state)
+		return;
+
+	channel->state = new_state;
+
+	struct gs_host_frame_object *frame_object = gs_host_frame_object_get_locked(hcan);
+	if (!frame_object)
+		return;
+
+	struct gs_host_frame *frame = &frame_object->frame;
+	can_prepare_error_frame(channel, frame);
+
+	if (channel->state == GS_CAN_STATE_BUS_OFF) {
+		frame->can_id |= CAN_ERR_BUSOFF;
+	} else {
+		frame->can_id |= CAN_ERR_CRTL | CAN_ERR_CNT;
+		can_drv_handle_state_change(channel, frame);
+	}
+
+	list_add_tail_locked(&frame_object->list, &hcan->list_to_host);
+}
+
 // If there are frames to receive, don't report any error frames. The
 // best we can localize the errors to is "after the last successfully
 // received frame", so wait until we get there. LEC will hold some error
@@ -237,4 +267,6 @@ void CAN_HandleError(USBD_GS_CAN_HandleTypeDef *hcan, can_data_t *channel)
 	} else {
 		list_add_tail_locked(&frame_object->list, &hcan->list_frame_pool);
 	}
+
+	can_handle_state_change(hcan, channel);
 }

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -24,6 +24,8 @@
  *
  */
 
+#include <string.h>
+
 #include "can_common.h"
 #include "can_drv.h"
 #include "host_frame.h"
@@ -143,6 +145,21 @@ void CAN_ReceiveFrame(USBD_GS_CAN_HandleTypeDef *hcan, can_data_t *channel)
 	list_add_tail_locked(&frame_object->list, &hcan->list_to_host);
 
 	led_indicate_trx(&channel->leds, LED_RX);
+}
+
+static void can_prepare_error_frame(const struct can_channel *channel,
+									struct gs_host_frame *frame)
+
+{
+	frame->echo_id = GS_HOST_FRAME_ECHO_ID_RX;
+	frame->can_id = CAN_ERR_FLAG;
+	frame->can_dlc = CAN_ERR_DLC;
+	frame->channel = can_channel_get_nr(channel);
+	frame->flags = 0;
+	frame->reserved = 0;
+	memset(frame->classic_can->data, 0x0, sizeof(frame->classic_can->data));
+
+	frame->classic_can_ts->timestamp_us = timer_get();
 }
 
 enum gs_can_state can_err_to_state(const uint16_t err)

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -138,7 +138,7 @@ void CAN_ReceiveFrame(USBD_GS_CAN_HandleTypeDef *hcan, can_data_t *channel)
 		return;
 	}
 
-	frame->echo_id = 0xFFFFFFFF; // not an echo frame
+	frame->echo_id = GS_HOST_FRAME_ECHO_ID_RX; // not an echo frame
 	frame->reserved = 0;
 
 	list_add_tail_locked(&frame_object->list, &hcan->list_to_host);

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -29,6 +29,7 @@
 
 #include "can.h"
 #include "can_common.h"
+#include "can_drv.h"
 #include "compiler.h"
 #include "config.h"
 #include "dfu.h"
@@ -435,6 +436,11 @@ static uint8_t USBD_GS_CAN_Config_Request(USBD_HandleTypeDef *pdev, USBD_SetupRe
 			src = &ep0->term_state;
 			len = sizeof(ep0->term_state);
 			break;
+		case GS_USB_BREQ_GET_STATE:
+			can_drv_get_device_state(channel, &ep0->state);
+			src = &ep0->state;
+			len = sizeof(ep0->state);
+			break;
 		case GS_USB_BREQ_SET_FILTER:
 			len = sizeof(ep0->filter);
 			break;
@@ -472,6 +478,7 @@ static uint8_t USBD_GS_CAN_Config_Request(USBD_HandleTypeDef *pdev, USBD_SetupRe
 		case GS_USB_BREQ_TIMESTAMP:
 		case GS_USB_BREQ_BT_CONST_EXT:
 		case GS_USB_BREQ_GET_TERMINATION:
+		case GS_USB_BREQ_GET_STATE:
 		case GS_USB_BREQ_GET_FILTER:
 			USBD_CtlSendData(pdev, (uint8_t *)src, len);
 			break;


### PR DESCRIPTION
This PR takes @jhofstee work from https://github.com/jhofstee/candleLight_fw/tree/canbus-state and ports it to current mainline. (Configurable Bus-Off handling is handled in a later PR.)

CAN state and CAN bus errors are handled independently, CAN error frames are only prepared if there is something to report. Further `GS_CAN_FEATURE_BERR_REPORTING` and `GS_USB_BREQ_GET_STATE` are implemented.

This increases max TX busload from on an STM32F072 from 97% to 99% using:

```
cangen can0 -I 2 -L1 -Di -p 10 -g 0.05 -c16
```

Closes: https://github.com/candle-usb/candleLight_fw/issues/154