### PR TITLE
bx_can: `can_drv_get_state()`: return current state if stopped or sleeping

### DIFF
--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -323,6 +323,9 @@ bool can_send(can_data_t *channel, struct gs_host_frame *frame)
 
 enum gs_can_state can_drv_get_state(const struct can_channel *channel)
 {
+	if (channel->state >= GS_CAN_STATE_STOPPED)
+		return channel->state;
+
 	const uint32_t reg_esr = channel->instance->ESR;
 
 	if (!(reg_esr & (CAN_ESR_BOFF | CAN_ESR_EPVF | CAN_ESR_EWGF))) {


### PR DESCRIPTION
During a `modprobe -r gs_usb; modprobe gs_usb` cycle the following spurious CAN error frame is generated:

```
 (2026-06-17 16:47:16.592988)     can0  RX - -  20000204   {8}  00 40 00 00 00 00 00 00   ERRORFRAME
        controller-problem{back-to-error-active}
        error-counter-tx-rx{{0}{0}}
```

Since commit 5ecbd1694f6d ("can_common, bxcan: improve CAN state handling"), when the firmware disables the interface it sets `struct can_channel::state` to `GS_CAN_STATE_STOPPED`.

The `main()` loop is still running, `can_handle_state_change()` will detect a state transition from `GS_CAN_STATE_STOPPED` to the actual CAN state, usually `GS_CAN_STATE_ERROR_ACTIVE` and generate a CAN state error message.

Fix the error by returning the current state if stopped or sleeping.

Fixes: 5ecbd1694f6d ("can_common, bxcan: improve CAN state handling")