### PR TITLE
add CAN bus error information to CAN state change error messages

### DIFF
--- a/include/can_drv.h
+++ b/include/can_drv.h
@@ -38,7 +38,7 @@ void can_drv_disable(struct can_channel *channel);
 uint32_t can_drv_read_reg_status(const struct can_channel *channel);
 
 bool can_drv_bus_error_pending(const uint32_t reg);
-void can_drv_handle_bus_error(const struct can_channel *channel, struct gs_host_frame *frame, const uint32_t reg);
+bool can_drv_handle_bus_error(const struct can_channel *channel, struct gs_host_frame *frame, const uint32_t reg);
 
 enum gs_can_state can_drv_get_state(const uint32_t reg);
 void can_drv_get_device_state(const struct can_channel *channel, struct gs_device_state *state, const uint32_t reg);

--- a/include/can_drv.h
+++ b/include/can_drv.h
@@ -36,9 +36,10 @@ void can_drv_enable(struct can_channel *channel);
 void can_drv_disable(struct can_channel *channel);
 
 uint32_t can_drv_read_reg_status(const struct can_channel *channel);
-enum gs_can_state can_drv_get_state(const uint32_t reg);
-void can_drv_handle_state_change(const struct can_channel *channel, struct gs_host_frame *frame, const uint32_t reg);
-void can_drv_get_device_state(const struct can_channel *channel, struct gs_device_state *state, const uint32_t reg);
 
 bool can_drv_bus_error_pending(const uint32_t reg);
 void can_drv_handle_bus_error(const struct can_channel *channel, struct gs_host_frame *frame, const uint32_t reg);
+
+enum gs_can_state can_drv_get_state(const uint32_t reg);
+void can_drv_get_device_state(const struct can_channel *channel, struct gs_device_state *state, const uint32_t reg);
+void can_drv_handle_state_change(const struct can_channel *channel, struct gs_host_frame *frame, const uint32_t reg);

--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -371,7 +371,7 @@ void can_drv_get_device_state(const struct can_channel __maybe_unused *channel, 
 	state->txerr = FIELD_GET(CAN_ESR_TEC, reg_esr);
 }
 
-void can_drv_handle_state_change(const struct can_channel __maybe_unused *channel, struct gs_host_frame *frame,
+void can_drv_handle_state_change(const struct can_channel *channel, struct gs_host_frame *frame,
 								 const uint32_t reg_esr)
 {
 	enum gs_can_state tx_state, rx_state;
@@ -390,4 +390,6 @@ void can_drv_handle_state_change(const struct can_channel __maybe_unused *channe
 
 	frame->classic_can->data[6] = tx_err;
 	frame->classic_can->data[7] = rx_err;
+
+	can_drv_handle_bus_error(channel, frame, reg_esr);
 }

--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -324,18 +324,26 @@ bool can_drv_bus_error_pending(const uint32_t reg_esr)
 	return can_is_lec_error(lec);
 }
 
-void can_drv_handle_bus_error(const struct can_channel __maybe_unused *channel, struct gs_host_frame *frame,
+bool can_drv_handle_bus_error(const struct can_channel __maybe_unused *channel, struct gs_host_frame *frame,
 							  const uint32_t reg_esr)
 {
+	const uint8_t tx_err = FIELD_GET(CAN_ESR_TEC, reg_esr);
+	const uint8_t rx_err = FIELD_GET(CAN_ESR_REC, reg_esr);
+
+	/* mark as handled by software */
+	channel->instance->ESR |= FIELD_PREP(CAN_ESR_LEC, CAN_LEC_SOFTWARE);
+
+	if (tx_err == 0 && rx_err == 0)
+		return false;
+
+	frame->classic_can->data[6] = tx_err;
+	frame->classic_can->data[7] = rx_err;
+
 	frame->can_id |= CAN_ERR_PROT | CAN_ERR_BUSERROR | CAN_ERR_CNT;
 
 	can_lec_error_to_frame(frame, FIELD_GET(CAN_ESR_LEC, reg_esr));
 
-	frame->classic_can->data[6] = FIELD_GET(CAN_ESR_TEC, reg_esr);
-	frame->classic_can->data[7] = FIELD_GET(CAN_ESR_REC, reg_esr);
-
-	/* mark as handled by software */
-	channel->instance->ESR |= FIELD_PREP(CAN_ESR_LEC, CAN_LEC_SOFTWARE);
+	return true;
 }
 
 enum gs_can_state can_drv_get_state(const uint32_t reg_esr)

--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -317,6 +317,27 @@ uint32_t can_drv_read_reg_status(const struct can_channel *channel)
 	return channel->instance->ESR;
 }
 
+bool can_drv_bus_error_pending(const uint32_t reg_esr)
+{
+	const uint32_t lec = FIELD_GET(CAN_ESR_LEC, reg_esr);
+
+	return can_is_lec_error(lec);
+}
+
+void can_drv_handle_bus_error(const struct can_channel __maybe_unused *channel, struct gs_host_frame *frame,
+							  const uint32_t reg_esr)
+{
+	frame->can_id |= CAN_ERR_PROT | CAN_ERR_BUSERROR | CAN_ERR_CNT;
+
+	can_lec_error_to_frame(frame, FIELD_GET(CAN_ESR_LEC, reg_esr));
+
+	frame->classic_can->data[6] = FIELD_GET(CAN_ESR_TEC, reg_esr);
+	frame->classic_can->data[7] = FIELD_GET(CAN_ESR_REC, reg_esr);
+
+	/* mark as handled by software */
+	channel->instance->ESR |= FIELD_PREP(CAN_ESR_LEC, CAN_LEC_SOFTWARE);
+}
+
 enum gs_can_state can_drv_get_state(const uint32_t reg_esr)
 {
 	if (!(reg_esr & (CAN_ESR_BOFF | CAN_ESR_EPVF | CAN_ESR_EWGF))) {
@@ -332,6 +353,14 @@ enum gs_can_state can_drv_get_state(const uint32_t reg_esr)
 	}
 
 	return GS_CAN_STATE_ERROR_WARNING;
+}
+
+void can_drv_get_device_state(const struct can_channel __maybe_unused *channel, struct gs_device_state *state,
+							  const uint32_t reg_esr)
+{
+	state->state = can_drv_get_state(reg_esr);
+	state->rxerr = FIELD_GET(CAN_ESR_REC, reg_esr);
+	state->txerr = FIELD_GET(CAN_ESR_TEC, reg_esr);
 }
 
 void can_drv_handle_state_change(const struct can_channel __maybe_unused *channel, struct gs_host_frame *frame,
@@ -353,33 +382,4 @@ void can_drv_handle_state_change(const struct can_channel __maybe_unused *channe
 
 	frame->classic_can->data[6] = tx_err;
 	frame->classic_can->data[7] = rx_err;
-}
-
-void can_drv_get_device_state(const struct can_channel __maybe_unused *channel, struct gs_device_state *state,
-							  const uint32_t reg_esr)
-{
-	state->state = can_drv_get_state(reg_esr);
-	state->rxerr = FIELD_GET(CAN_ESR_REC, reg_esr);
-	state->txerr = FIELD_GET(CAN_ESR_TEC, reg_esr);
-}
-
-bool can_drv_bus_error_pending(const uint32_t reg_esr)
-{
-	const uint32_t lec = FIELD_GET(CAN_ESR_LEC, reg_esr);
-
-	return can_is_lec_error(lec);
-}
-
-void can_drv_handle_bus_error(const struct can_channel __maybe_unused *channel, struct gs_host_frame *frame,
-							  const uint32_t reg_esr)
-{
-	frame->can_id |= CAN_ERR_PROT | CAN_ERR_BUSERROR | CAN_ERR_CNT;
-
-	can_lec_error_to_frame(frame, FIELD_GET(CAN_ESR_LEC, reg_esr));
-
-	frame->classic_can->data[6] = FIELD_GET(CAN_ESR_TEC, reg_esr);
-	frame->classic_can->data[7] = FIELD_GET(CAN_ESR_REC, reg_esr);
-
-	/* mark as handled by software */
-	channel->instance->ESR |= FIELD_PREP(CAN_ESR_LEC, CAN_LEC_SOFTWARE);
 }

--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -317,11 +317,6 @@ uint32_t can_drv_read_reg_status(const struct can_channel *channel)
 	return channel->instance->ESR;
 }
 
-void can_drv_clear_reg_status(const struct can_channel *channel)
-{
-	channel->instance->ESR |= FIELD_PREP(CAN_ESR_LEC, CAN_LEC_SOFTWARE);
-}
-
 enum gs_can_state can_drv_get_state(const uint32_t reg_esr)
 {
 	if (!(reg_esr & (CAN_ESR_BOFF | CAN_ESR_EPVF | CAN_ESR_EWGF))) {

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -247,9 +247,12 @@ static void can_handle_bus_error(USBD_GS_CAN_HandleTypeDef *hcan, const struct c
 	struct gs_host_frame *frame = &frame_object->frame;
 
 	can_prepare_error_frame(channel, frame);
-	can_drv_handle_bus_error(channel, frame, reg_status);
-
-	list_add_tail_locked(&frame_object->list, &hcan->list_to_host);
+	bool handled = can_drv_handle_bus_error(channel, frame, reg_status);
+	if (handled) {
+		list_add_tail_locked(&frame_object->list, &hcan->list_to_host);
+	} else {
+		list_add_locked(&frame_object->list, &hcan->list_frame_pool);
+	}
 }
 
 static void can_handle_state_change(USBD_GS_CAN_HandleTypeDef *hcan, struct can_channel *channel,


### PR DESCRIPTION
With commit 4cf2b41f972d ("Merge pull request #303 from marckleinebudde/can-error-handling") the firmware implements CAN bus error reporting (`GS_CAN_FEATURE_BERR_REPORTING`).

With that series CAN state change error messages and CAN bus error messages (which are disabled by default) are send separately.

This means CAN state change messages never contain any information about the CAN bus error, even if there is one. In https://github.com/candle-usb/candleLight_fw/issues/308 @Elmue pointed out that this might break existing applications.

To avoid this breakage, always augment all CAN state change error messages with CAN bus error information, even if CAN bus error reporting is not enabled.

Closes: https://github.com/candle-usb/candleLight_fw/issues/308