### PR TITLE
add software based CAN bus off handling

### DIFF
--- a/include/can.h
+++ b/include/can.h
@@ -34,6 +34,8 @@
 #include "led.h"
 #include "list.h"
 
+#define CAN_CHANNEL_BUS_OFF_RESTART_DISABLED 0
+
 typedef struct can_channel {
 #if defined (CONFIG_BXCAN)
 	CAN_TypeDef *instance;
@@ -42,6 +44,7 @@ typedef struct can_channel {
 	led_data_t leds;
 	uint32_t feature;
 	enum gs_can_state state;
+	uint32_t bus_off_restart;
 #if defined (CONFIG_BXCAN)
 	struct gs_device_filter filter;
 	uint32_t btr;

--- a/include/can.h
+++ b/include/can.h
@@ -78,8 +78,6 @@ static inline void can_set_filter(can_data_t __maybe_unused *channel, const stru
 }
 #endif
 
-bool can_is_enabled(can_data_t *channel);
-
 bool can_receive(can_data_t *channel, struct gs_host_frame *rx_frame);
 bool can_is_rx_pending(can_data_t *channel);
 

--- a/include/can_common.h
+++ b/include/can_common.h
@@ -90,6 +90,8 @@ uint8_t gs_can_tx_state_to_frame(const enum gs_can_state state);
 uint8_t gs_can_rx_state_to_frame(const enum gs_can_state state);
 void can_lec_error_to_frame(struct gs_host_frame *frame, const uint8_t lec);
 
+void can_schedule_bus_off_recovery(struct can_channel *channel, uint32_t delay_ms);
+
 void CAN_SendFrame(USBD_GS_CAN_HandleTypeDef *hcan, can_data_t *channel);
 void CAN_ReceiveFrame(USBD_GS_CAN_HandleTypeDef *hcan, can_data_t *channel);
 void CAN_HandleError(USBD_GS_CAN_HandleTypeDef *hcan, can_data_t *channel);

--- a/include/can_common.h
+++ b/include/can_common.h
@@ -80,6 +80,7 @@ static inline bool can_is_lec_error(const uint8_t lec)
 	return true;
 }
 
+bool can_is_enabled(const struct can_channel *channel);
 void can_enable(struct can_channel *channel, uint32_t mode);
 void can_disable(USBD_GS_CAN_HandleTypeDef *hcan, struct can_channel *channel);
 void can_get_device_state(const struct can_channel *channel, struct gs_device_state *state);

--- a/include/can_drv.h
+++ b/include/can_drv.h
@@ -43,3 +43,5 @@ bool can_drv_handle_bus_error(const struct can_channel *channel, struct gs_host_
 enum gs_can_state can_drv_get_state(const uint32_t reg);
 void can_drv_get_device_state(const struct can_channel *channel, struct gs_device_state *state, const uint32_t reg);
 void can_drv_handle_state_change(const struct can_channel *channel, struct gs_host_frame *frame, const uint32_t reg);
+
+void can_drv_handle_bus_off_recovery(struct can_channel *channel);

--- a/include/util.h
+++ b/include/util.h
@@ -29,6 +29,8 @@
 #include <stdbool.h>
 #include <cmsis_device.h>
 
+#define time_after(a, b) ((int)((b) - (a)) < 0)
+
 void hex32(char *out, uint32_t val);
 
 // ARM's

--- a/include/util.h
+++ b/include/util.h
@@ -1,28 +1,27 @@
 /*
-
-The MIT License (MIT)
-
-Copyright (c) 2016, 2019 Hubert Denkmair
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-*/
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016, 2019 Hubert Denkmair
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
 
 #pragma once
 

--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -200,13 +200,6 @@ void can_drv_disable(struct can_channel *channel)
 	can->MCR |= CAN_MCR_INRQ;     // send can controller into initialization mode
 }
 
-bool can_is_enabled(can_data_t *channel)
-{
-	CAN_TypeDef *can = channel->instance;
-
-	return (can->MCR & CAN_MCR_INRQ) == 0;
-}
-
 bool can_is_rx_pending(can_data_t *channel)
 {
 	CAN_TypeDef *can = channel->instance;

--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -24,7 +24,6 @@
  *
  */
 
-#include "board.h"
 #include "can.h"
 #include "can_common.h"
 #include "can_drv.h"
@@ -188,15 +187,12 @@ void can_drv_enable(struct can_channel *channel)
 
 	can->MCR &= ~CAN_MCR_INRQ;
 	while ((can->MSR & CAN_MSR_INAK) != 0);
-
-	board_phy_power_set(channel, true);
 }
 
 void can_drv_disable(struct can_channel *channel)
 {
 	CAN_TypeDef *can = channel->instance;
 
-	board_phy_power_set(channel, false);
 	can->MCR |= CAN_MCR_INRQ;     // send can controller into initialization mode
 }
 

--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -153,7 +153,7 @@ void can_drv_enable(struct can_channel *channel)
 	const uint32_t feature = channel->feature;
 	CAN_TypeDef *can = channel->instance;
 
-	uint32_t mcr = CAN_MCR_INRQ | CAN_MCR_ABOM | CAN_MCR_TXFP;
+	uint32_t mcr = CAN_MCR_INRQ | CAN_MCR_TXFP;
 
 	if (feature & GS_CAN_FEATURE_ONE_SHOT) {
 		mcr |= CAN_MCR_NART;
@@ -384,4 +384,10 @@ void can_drv_handle_state_change(const struct can_channel __maybe_unused *channe
 	if (tx_state <= rx_state) {
 		frame->classic_can->data[1] |= gs_can_rx_state_to_frame(rx_state);
 	}
+}
+
+void can_drv_handle_bus_off_recovery(struct can_channel *channel)
+{
+	can_drv_disable(channel);
+	can_drv_enable(channel);
 }

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -24,8 +24,6 @@
  *
  */
 
-#include <string.h>
-
 #include "can_common.h"
 #include "can_drv.h"
 #include "host_frame.h"
@@ -167,7 +165,7 @@ static void can_prepare_error_frame(const struct can_channel *channel,
 	frame->channel = can_channel_get_nr(channel);
 	frame->flags = 0;
 	frame->reserved = 0;
-	memset(frame->classic_can->data, 0x0, sizeof(frame->classic_can->data));
+	*frame->classic_can = (struct classic_can){ 0 };
 
 	frame->classic_can_ts->timestamp_us = timer_get();
 }

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -291,7 +291,7 @@ static void can_handle_state_change(USBD_GS_CAN_HandleTypeDef *hcan, struct can_
 
 static bool can_state_change_pending(struct can_channel *channel, const uint32_t reg_status)
 {
-	if (channel->state >= GS_CAN_STATE_STOPPED)
+	if (!can_is_enabled(channel))
 		return false;
 
 	const enum gs_can_state new_state = can_drv_get_state(reg_status);

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -319,11 +319,22 @@ static bool can_state_change_pending(struct can_channel *channel, const uint32_t
 	return true;
 }
 
-static void can_handle_bus_off_recovery(USBD_GS_CAN_HandleTypeDef __maybe_unused *hcan, struct can_channel *channel)
+static void can_handle_bus_off_recovery(USBD_GS_CAN_HandleTypeDef *hcan, struct can_channel *channel)
 {
 	can_drv_handle_bus_off_recovery(channel);
 
 	channel->bus_off_restart = CAN_CHANNEL_BUS_OFF_RESTART_DISABLED;
+
+	struct gs_host_frame_object *frame_object = gs_host_frame_object_get_locked(hcan);
+	if (!frame_object)
+		return;
+
+	struct gs_host_frame *frame = &frame_object->frame;
+	can_prepare_error_frame(channel, frame);
+
+	frame->can_id |= CAN_ERR_RESTARTED;
+
+	list_add_tail_locked(&frame_object->list, &hcan->list_to_host);
 }
 
 static bool can_bus_off_recovery_pending(const struct can_channel *channel)

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -67,6 +67,11 @@ bool can_check_filter_ok(const struct gs_device_filter *filter)
 }
 #endif
 
+bool can_is_enabled(const struct can_channel *channel)
+{
+	return channel->state < GS_CAN_STATE_STOPPED;
+}
+
 void can_enable(struct can_channel *channel, const uint32_t feature)
 {
 	channel->feature = feature;

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -32,9 +32,11 @@
 #include "timer.h"
 #include "usbd_gs_can.h"
 
-#define CAN_ERROR_WARNING_THRESHOLD 96
-#define CAN_ERROR_PASSIVE_THRESHOLD 128
-#define CAN_BUS_OFF_THRESHOLD		256
+#define CAN_ERROR_WARNING_THRESHOLD	 96
+#define CAN_ERROR_PASSIVE_THRESHOLD	 128
+#define CAN_BUS_OFF_THRESHOLD		 256
+
+#define CAN_BUS_OFF_RESTART_DELAY_MS 100
 
 #ifndef CONFIG_CANFD
 const struct gs_device_bt_const_extended CAN_btconst_ext;
@@ -89,6 +91,8 @@ void can_disable(USBD_GS_CAN_HandleTypeDef *hcan, struct can_channel *channel)
 	board_phy_power_set(channel, false);
 	usbd_gs_can_purge_from_host_list_by_channel(hcan, channel);
 	usbd_gs_can_purge_to_host_list_by_channel(hcan, channel);
+
+	channel->bus_off_restart = CAN_CHANNEL_BUS_OFF_RESTART_DISABLED;
 	channel->state = GS_CAN_STATE_STOPPED;
 	led_set_mode(&channel->leds, LED_MODE_OFF);
 }
@@ -271,6 +275,14 @@ static bool can_bus_error_pending(const struct can_channel *channel, const uint3
 	return can_drv_bus_error_pending(reg_status);
 }
 
+void can_schedule_bus_off_recovery(struct can_channel *channel, const uint32_t delay_ms)
+{
+	channel->bus_off_restart = HAL_GetTick() + delay_ms;
+
+	if (channel->bus_off_restart == CAN_CHANNEL_BUS_OFF_RESTART_DISABLED)
+		channel->bus_off_restart++;
+}
+
 static void can_handle_state_change(USBD_GS_CAN_HandleTypeDef *hcan, struct can_channel *channel,
 									const uint32_t reg_status)
 {
@@ -283,6 +295,7 @@ static void can_handle_state_change(USBD_GS_CAN_HandleTypeDef *hcan, struct can_
 
 	if (channel->state == GS_CAN_STATE_BUS_OFF) {
 		frame->can_id |= CAN_ERR_BUSOFF;
+		can_schedule_bus_off_recovery(channel, CAN_BUS_OFF_RESTART_DELAY_MS);
 	} else {
 		frame->can_id |= CAN_ERR_CRTL | CAN_ERR_CNT;
 		can_drv_handle_state_change(channel, frame, reg_status);
@@ -306,6 +319,23 @@ static bool can_state_change_pending(struct can_channel *channel, const uint32_t
 	return true;
 }
 
+static void can_handle_bus_off_recovery(USBD_GS_CAN_HandleTypeDef __maybe_unused *hcan, struct can_channel *channel)
+{
+	can_drv_handle_bus_off_recovery(channel);
+
+	channel->bus_off_restart = CAN_CHANNEL_BUS_OFF_RESTART_DISABLED;
+}
+
+static bool can_bus_off_recovery_pending(const struct can_channel *channel)
+{
+	if (channel->bus_off_restart == CAN_CHANNEL_BUS_OFF_RESTART_DISABLED)
+		return false;
+
+	const uint32_t now = HAL_GetTick();
+
+	return time_after(now, channel->bus_off_restart);
+}
+
 // If there are frames to receive, don't report any error frames. The
 // best we can localize the errors to is "after the last successfully
 // received frame", so wait until we get there. LEC will hold some error
@@ -322,5 +352,7 @@ void CAN_HandleError(USBD_GS_CAN_HandleTypeDef *hcan, can_data_t *channel)
 		can_handle_state_change(hcan, channel, reg_status);
 	} else if (can_bus_error_pending(channel, reg_status)) {
 		can_handle_bus_error(hcan, channel, reg_status);
+	} else if (can_bus_off_recovery_pending(channel)) {
+		can_handle_bus_off_recovery(hcan, channel);
 	}
 }

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -24,6 +24,7 @@
  *
  */
 
+#include "board.h"
 #include "can_common.h"
 #include "can_drv.h"
 #include "host_frame.h"
@@ -78,12 +79,14 @@ void can_enable(struct can_channel *channel, const uint32_t feature)
 
 	led_set_mode(&channel->leds, LED_MODE_NORMAL);
 	channel->state = GS_CAN_STATE_ERROR_ACTIVE;
+	board_phy_power_set(channel, true);
 	can_drv_enable(channel);
 }
 
 void can_disable(USBD_GS_CAN_HandleTypeDef *hcan, struct can_channel *channel)
 {
 	can_drv_disable(channel);
+	board_phy_power_set(channel, false);
 	usbd_gs_can_purge_from_host_list_by_channel(hcan, channel);
 	usbd_gs_can_purge_to_host_list_by_channel(hcan, channel);
 	channel->state = GS_CAN_STATE_STOPPED;


### PR DESCRIPTION
Switch off CAN bus error auto recovery in the bxcan IP core and implement a software based CAN bus off recovery after 100ms.

This is preparation for the m_can IP core, which doesn't have automatic CAN bus off recovery at all.