### PR TITLE
purge unprocessed USB out transfers

### DIFF
--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -110,6 +110,9 @@ typedef struct {
 	bool dfu_detach_requested;
 } USBD_GS_CAN_HandleTypeDef __attribute__ ((aligned (4)));
 
+void usbd_gs_can_purge_from_host_list_by_channel(USBD_GS_CAN_HandleTypeDef *hcan,
+												 struct can_channel *channel);
+
 void usbd_gs_can_purge_to_host_list_by_channel(USBD_GS_CAN_HandleTypeDef *hcan,
 											   const struct can_channel *channel);
 

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -81,6 +81,7 @@ void can_enable(struct can_channel *channel, const uint32_t feature)
 void can_disable(USBD_GS_CAN_HandleTypeDef *hcan, struct can_channel *channel)
 {
 	can_drv_disable(channel);
+	usbd_gs_can_purge_from_host_list_by_channel(hcan, channel);
 	usbd_gs_can_purge_to_host_list_by_channel(hcan, channel);
 	channel->state = GS_CAN_STATE_STOPPED;
 	led_set_mode(&channel->leds, LED_MODE_OFF);

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -216,6 +216,12 @@ static const struct gs_device_config USBD_GS_CAN_dconf = {
 	.hw_version = 1,
 };
 
+void usbd_gs_can_purge_from_host_list_by_channel(USBD_GS_CAN_HandleTypeDef *hcan,
+												 struct can_channel *channel)
+{
+	list_splice_tail_init_locked(&channel->list_from_host, &hcan->list_frame_pool);
+}
+
 void usbd_gs_can_purge_to_host_list_by_channel(USBD_GS_CAN_HandleTypeDef *hcan,
 											   const struct can_channel *channel)
 {


### PR DESCRIPTION
This fixes the following error messages, which might occur during suspend/resume:

```
[175499.859858] gs_usb 2-1.2:1.0 can0: Unexpected unused echo id 0
[175499.859955] gs_usb 2-1.2:1.0 can0: Unexpected unused echo id 1
[175499.859977] gs_usb 2-1.2:1.0 can0: Unexpected unused echo id 2
[175499.859994] gs_usb 2-1.2:1.0 can0: Unexpected unused echo id 3
[175499.860075] gs_usb 2-1.2:1.0 can0: Unexpected unused echo id 4
[175499.860097] gs_usb 2-1.2:1.0 can0: Unexpected unused echo id 5
[175499.860205] gs_usb 2-1.2:1.0 can0: Unexpected unused echo id 6
[175499.860227] gs_usb 2-1.2:1.0 can0: Unexpected unused echo id 7
[175499.860347] gs_usb 2-1.2:1.0 can0: Unexpected unused echo id 8
[175499.860368] gs_usb 2-1.2:1.0 can0: Unexpected unused echo id 9
``` 

While https://github.com/candle-usb/candleLight_fw/pull/301 purges pending USB in transfers, this PR purges unprocessed USB out transfers.