### PR TITLE
add new feature CAN bus off recovery

### DIFF
--- a/include/can_common.h
+++ b/include/can_common.h
@@ -90,6 +90,7 @@ uint8_t gs_can_tx_state_to_frame(const enum gs_can_state state);
 uint8_t gs_can_rx_state_to_frame(const enum gs_can_state state);
 void can_lec_error_to_frame(struct gs_host_frame *frame, const uint8_t lec);
 
+bool can_check_bus_off_recovery_ok(const struct can_channel *channel);
 void can_schedule_bus_off_recovery(struct can_channel *channel, uint32_t delay_ms);
 
 void CAN_SendFrame(USBD_GS_CAN_HandleTypeDef *hcan, can_data_t *channel);

--- a/include/gs_usb.h
+++ b/include/gs_usb.h
@@ -75,6 +75,11 @@
  * - struct gs_device_filter
  */
 #define GS_CAN_FEATURE_FILTER							  (1<<16)
+/* device support CAN bus off recovery
+ * - GS_USB_BREQ_BUS_OFF_RECOVERY
+ * - struct gs_device_bus_off_recovery
+ */
+#define GS_CAN_FEATURE_BUS_OFF_RECOVERY					  (1<<18)
 
 #define GS_CAN_FLAG_OVERFLOW							  (1<<0)
 #define GS_CAN_FLAG_FD									  (1<<1) /* is a CAN-FD frame */
@@ -196,6 +201,7 @@ enum gs_usb_breq {
 	__GS_USB_BREQ_ELM_PLACEHOLDER_29,
 	__GS_USB_BREQ_ELM_PLACEHOLDER_30,
 	__GS_USB_BREQ_ELM_PLACEHOLDER_31,
+	GS_USB_BREQ_BUS_OFF_RECOVERY = 32,
 };
 
 enum gs_can_mode {
@@ -317,6 +323,10 @@ struct gs_device_filter {
 	union {
 		struct gs_device_filter_bxcan bxcan;
 	};
+} __packed __aligned(4);
+
+struct gs_device_bus_off_recovery {
+	u32 unused;
 } __packed __aligned(4);
 
 struct classic_can {

--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -46,6 +46,7 @@ const struct gs_device_bt_const CAN_btconst = {
 		GS_CAN_FEATURE_GET_STATE |
 		(IS_ENABLED(CONFIG_CAN_FILTER) ?
 		 GS_CAN_FEATURE_FILTER : 0) |
+		GS_CAN_FEATURE_BUS_OFF_RECOVERY |
 		0,
 	.fclk_can = CAN_CLOCK_SPEED,
 	.btc = {

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -275,6 +275,12 @@ static bool can_bus_error_pending(const struct can_channel *channel, const uint3
 	return can_drv_bus_error_pending(reg_status);
 }
 
+bool can_check_bus_off_recovery_ok(const struct can_channel *channel)
+{
+	return channel->feature & GS_CAN_FEATURE_BUS_OFF_RECOVERY &&
+		   channel->state == GS_CAN_STATE_BUS_OFF;
+}
+
 void can_schedule_bus_off_recovery(struct can_channel *channel, const uint32_t delay_ms)
 {
 	channel->bus_off_restart = HAL_GetTick() + delay_ms;
@@ -295,7 +301,10 @@ static void can_handle_state_change(USBD_GS_CAN_HandleTypeDef *hcan, struct can_
 
 	if (channel->state == GS_CAN_STATE_BUS_OFF) {
 		frame->can_id |= CAN_ERR_BUSOFF;
-		can_schedule_bus_off_recovery(channel, CAN_BUS_OFF_RESTART_DELAY_MS);
+
+		/* host is not taking care of CAN bus of recovery */
+		if (!(channel->feature & GS_CAN_FEATURE_BUS_OFF_RECOVERY))
+			can_schedule_bus_off_recovery(channel, CAN_BUS_OFF_RESTART_DELAY_MS);
 	} else {
 		frame->can_id |= CAN_ERR_CRTL | CAN_ERR_CNT;
 		can_drv_handle_state_change(channel, frame, reg_status);

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -453,6 +453,9 @@ static uint8_t USBD_GS_CAN_Config_Request(USBD_HandleTypeDef *pdev, USBD_SetupRe
 			src = &CAN_filter_info;
 			len = sizeof(CAN_filter_info);
 			break;
+		case GS_USB_BREQ_BUS_OFF_RECOVERY:
+			len = 0;
+			break;
 		default:
 			goto out_fail;
 	}
@@ -469,6 +472,7 @@ static uint8_t USBD_GS_CAN_Config_Request(USBD_HandleTypeDef *pdev, USBD_SetupRe
 		case GS_USB_BREQ_DATA_BITTIMING:
 		case GS_USB_BREQ_SET_TERMINATION:
 		case GS_USB_BREQ_SET_FILTER:
+		case GS_USB_BREQ_BUS_OFF_RECOVERY:
 			if (req->wLength > sizeof(*ep0)) {
 				goto out_fail;
 			}
@@ -650,6 +654,13 @@ static uint8_t USBD_GS_CAN_EP0_RxReady(USBD_HandleTypeDef *pdev) {
 			can_set_filter(channel, filter);
 			break;
 		}
+		case GS_USB_BREQ_BUS_OFF_RECOVERY:
+			if (!can_is_enabled(channel) || !can_check_bus_off_recovery_ok(channel))
+				goto out_fail;
+
+			can_schedule_bus_off_recovery(channel, 0);
+			break;
+
 		default:
 			break;
 	}


### PR DESCRIPTION
For proper Linux integration add `GS_CAN_FEATURE_BUS_OFF_RECOVERY`. If enabled the firmware doesn't do automatic CAN bus off recovery. A CAN bus off recovery can be triggered with a `GS_USB_BREQ_BUS_OFF_RECOVERY` USB control message.