### PR TITLE
Add tdc support

### DIFF
--- a/include/can.h
+++ b/include/can.h
@@ -52,9 +52,9 @@ typedef struct can_channel {
 	uint32_t feature;
 	enum gs_can_state state;
 	uint32_t bus_off_restart;
+	struct gs_device_bittiming bittiming;
 #if defined (CONFIG_BXCAN)
 	struct gs_device_filter filter;
-	uint32_t btr;
 #endif
 #if (NUM_CAN_CHANNEL > 1)
 	uint8_t nr;

--- a/include/can.h
+++ b/include/can.h
@@ -34,12 +34,19 @@
 #include "led.h"
 #include "list.h"
 
+struct can_drv_reg_status {
+#if defined (CONFIG_BXCAN)
+	uint32_t esr;
+#endif
+};
+
 #define CAN_CHANNEL_BUS_OFF_RESTART_DISABLED 0
 
 typedef struct can_channel {
 #if defined (CONFIG_BXCAN)
 	CAN_TypeDef *instance;
 #endif
+	struct can_drv_reg_status reg_status;
 	struct list_head list_from_host;
 	led_data_t leds;
 	uint32_t feature;

--- a/include/can.h
+++ b/include/can.h
@@ -53,6 +53,9 @@ typedef struct can_channel {
 	enum gs_can_state state;
 	uint32_t bus_off_restart;
 	struct gs_device_bittiming bittiming;
+#ifdef CONFIG_CANFD
+	struct gs_device_bittiming data_bittiming;
+#endif
 #if defined (CONFIG_BXCAN)
 	struct gs_device_filter filter;
 #endif

--- a/include/can.h
+++ b/include/can.h
@@ -68,17 +68,6 @@ extern const struct gs_device_filter_info CAN_filter_info;
 struct board_channel_config;
 
 void can_init(can_data_t *channel, const struct board_channel_config *config);
-void can_set_bittiming(can_data_t *channel, const struct gs_device_bittiming *timing);
-
-#ifdef CONFIG_CANFD
-void can_set_data_bittiming(can_data_t *channel, const struct gs_device_bittiming *timing);
-#else
-static inline bool can_set_data_bittiming(can_data_t __maybe_unused *channel,
-										  const struct gs_device_bittiming __maybe_unused *timing)
-{
-	return false;
-}
-#endif
 
 #ifdef CONFIG_CAN_FILTER
 void can_set_filter(can_data_t *channel, const struct gs_device_filter *filter);

--- a/include/can.h
+++ b/include/can.h
@@ -73,6 +73,7 @@ typedef struct can_channel {
 extern const struct gs_device_bt_const CAN_btconst;
 extern const struct gs_device_bt_const_extended CAN_btconst_ext;
 extern const struct gs_device_filter_info CAN_filter_info;
+extern const struct gs_device_tdc_const CAN_tdc_const;
 
 struct board_channel_config;
 

--- a/include/can.h
+++ b/include/can.h
@@ -40,6 +40,11 @@ struct can_drv_reg_status {
 #endif
 };
 
+enum can_channel_flag {
+	CAN_CHANNEL_FLAG_BITTIMING_SET = BIT(0),
+	CAN_CHANNEL_FLAG_DATA_BITTIMING_SET = BIT(1),
+};
+
 #define CAN_CHANNEL_BUS_OFF_RESTART_DISABLED 0
 
 typedef struct can_channel {
@@ -50,6 +55,7 @@ typedef struct can_channel {
 	struct list_head list_from_host;
 	led_data_t leds;
 	uint32_t feature;
+	enum can_channel_flag flags;
 	enum gs_can_state state;
 	uint32_t bus_off_restart;
 	struct gs_device_bittiming bittiming;

--- a/include/can.h
+++ b/include/can.h
@@ -43,6 +43,7 @@ struct can_drv_reg_status {
 enum can_channel_flag {
 	CAN_CHANNEL_FLAG_BITTIMING_SET = BIT(0),
 	CAN_CHANNEL_FLAG_DATA_BITTIMING_SET = BIT(1),
+	CAN_CHANNEL_FLAG_TDC_SET = BIT(2),
 };
 
 #define CAN_CHANNEL_BUS_OFF_RESTART_DISABLED 0
@@ -61,6 +62,7 @@ typedef struct can_channel {
 	struct gs_device_bittiming bittiming;
 #ifdef CONFIG_CANFD
 	struct gs_device_bittiming data_bittiming;
+	struct gs_device_tdc tdc;
 #endif
 #if defined (CONFIG_BXCAN)
 	struct gs_device_filter filter;

--- a/include/can_common.h
+++ b/include/can_common.h
@@ -46,9 +46,22 @@ void can_set_bittiming(struct can_channel *channel, const struct gs_device_bitti
 
 #ifdef CONFIG_CANFD
 void can_set_data_bittiming(struct can_channel *channel, const struct gs_device_bittiming *timing);
+bool can_check_tdc_ok(const struct gs_device_tdc_const *tdc_const, const struct gs_device_tdc *tdc);
+void can_set_tdc(struct can_channel *channel, const struct gs_device_tdc *tdc);
 #else
 static inline void can_set_data_bittiming(struct can_channel __maybe_unused *channel,
 										  const struct gs_device_bittiming __maybe_unused *timing)
+{
+}
+
+static inline bool can_check_tdc_ok(const struct gs_device_tdc_const __maybe_unused *tdc_const,
+									const struct gs_device_tdc __maybe_unused *tdc)
+{
+	return false;
+}
+
+static inline void can_set_tdc(struct can_channel __maybe_unused *channel,
+							   const struct gs_device_tdc __maybe_unused *tdc)
 {
 }
 #endif

--- a/include/can_common.h
+++ b/include/can_common.h
@@ -48,6 +48,7 @@ void can_set_bittiming(struct can_channel *channel, const struct gs_device_bitti
 void can_set_data_bittiming(struct can_channel *channel, const struct gs_device_bittiming *timing);
 bool can_check_tdc_ok(const struct gs_device_tdc_const *tdc_const, const struct gs_device_tdc *tdc);
 void can_set_tdc(struct can_channel *channel, const struct gs_device_tdc *tdc);
+void can_get_device_tdc(const struct can_channel *channel, struct gs_device_tdc *tdc);
 #else
 static inline void can_set_data_bittiming(struct can_channel __maybe_unused *channel,
 										  const struct gs_device_bittiming __maybe_unused *timing)
@@ -62,6 +63,11 @@ static inline bool can_check_tdc_ok(const struct gs_device_tdc_const __maybe_unu
 
 static inline void can_set_tdc(struct can_channel __maybe_unused *channel,
 							   const struct gs_device_tdc __maybe_unused *tdc)
+{
+}
+
+static inline void can_get_device_tdc(const struct can_channel __maybe_unused *channel,
+									  struct gs_device_tdc __maybe_unused *tdc)
 {
 }
 #endif

--- a/include/can_common.h
+++ b/include/can_common.h
@@ -40,6 +40,7 @@
 #define CAN_LEC_CRC_ERROR	6
 #define CAN_LEC_SOFTWARE	7
 
+bool can_check_feature_ok(const can_data_t *channel, const uint32_t feature);
 bool can_check_bittiming_ok(const struct can_bittiming_const *btc, const struct gs_device_bittiming *timing);
 void can_set_bittiming(struct can_channel *channel, const struct gs_device_bittiming *bt);
 

--- a/include/can_common.h
+++ b/include/can_common.h
@@ -41,6 +41,16 @@
 #define CAN_LEC_SOFTWARE	7
 
 bool can_check_bittiming_ok(const struct can_bittiming_const *btc, const struct gs_device_bittiming *timing);
+void can_set_bittiming(struct can_channel *channel, const struct gs_device_bittiming *bt);
+
+#ifdef CONFIG_CANFD
+void can_set_data_bittiming(struct can_channel *channel, const struct gs_device_bittiming *timing);
+#else
+static inline void can_set_data_bittiming(struct can_channel __maybe_unused *channel,
+										  const struct gs_device_bittiming __maybe_unused *timing)
+{
+}
+#endif
 
 #ifdef CONFIG_CAN_FILTER
 bool can_check_filter_ok(const struct gs_device_filter *filter);

--- a/include/can_drv.h
+++ b/include/can_drv.h
@@ -31,10 +31,13 @@
 struct can_channel;
 struct can_drv_reg_status;
 struct gs_device_state;
+struct gs_device_tdc;
 struct gs_host_frame;
 
 void can_drv_enable(struct can_channel *channel);
 void can_drv_disable(struct can_channel *channel);
+
+void can_drv_get_device_tdc(const struct can_channel *channel, struct gs_device_tdc *tdc);
 
 void can_drv_read_reg_status(struct can_channel *channel);
 

--- a/include/can_drv.h
+++ b/include/can_drv.h
@@ -29,19 +29,20 @@
 #include <stdint.h>
 
 struct can_channel;
+struct can_drv_reg_status;
 struct gs_device_state;
 struct gs_host_frame;
 
 void can_drv_enable(struct can_channel *channel);
 void can_drv_disable(struct can_channel *channel);
 
-uint32_t can_drv_read_reg_status(const struct can_channel *channel);
+void can_drv_read_reg_status(struct can_channel *channel);
 
-bool can_drv_bus_error_pending(const uint32_t reg);
-bool can_drv_handle_bus_error(const struct can_channel *channel, struct gs_host_frame *frame, const uint32_t reg);
+bool can_drv_bus_error_pending(const struct can_channel *channel);
+bool can_drv_handle_bus_error(const struct can_channel *channel, struct gs_host_frame *frame);
 
-enum gs_can_state can_drv_get_state(const uint32_t reg);
-void can_drv_get_device_state(const struct can_channel *channel, struct gs_device_state *state, const uint32_t reg);
-void can_drv_handle_state_change(const struct can_channel *channel, struct gs_host_frame *frame, const uint32_t reg);
+enum gs_can_state can_drv_get_state(const struct can_channel *channel);
+void can_drv_get_device_state(const struct can_channel *channel, struct gs_device_state *state);
+void can_drv_handle_state_change(const struct can_channel *channel, struct gs_host_frame *frame);
 
 void can_drv_handle_bus_off_recovery(struct can_channel *channel);

--- a/include/gs_usb.h
+++ b/include/gs_usb.h
@@ -75,6 +75,14 @@
  * - struct gs_device_filter
  */
 #define GS_CAN_FEATURE_FILTER							  (1<<16)
+/* device supports TDC configuration, see:
+ * - GS_USB_BREQ_GET_TDC_CONST
+ * - GS_USB_BREQ_SET_TDC
+ * - GS_USB_BREQ_GET_TDC
+ * - struct gs_device_tdc_const
+ * - struct gs_device_tdc
+ */
+#define GS_CAN_FEATURE_TDC								  (1<<17)
 /* device support CAN bus off recovery
  * - GS_USB_BREQ_BUS_OFF_RECOVERY
  * - struct gs_device_bus_off_recovery
@@ -186,9 +194,9 @@ enum gs_usb_breq {
 	GS_USB_BREQ_GET_STATE,
 	GS_USB_BREQ_SET_FILTER,
 	GS_USB_BREQ_GET_FILTER,
-	__GS_USB_BREQ_PLACEHOLDER_17,
-	__GS_USB_BREQ_PLACEHOLDER_18,
-	__GS_USB_BREQ_PLACEHOLDER_19,
+	GS_USB_BREQ_GET_TDC_CONST,
+	GS_USB_BREQ_SET_TDC,
+	GS_USB_BREQ_GET_TDC,
 	GS_USB_BREQ_ELM_GET_BOARDINFO = 20,
 	GS_USB_BREQ_ELM_SET_FILTER,
 	GS_USB_BREQ_ELM_GET_LASTERROR,
@@ -323,6 +331,29 @@ struct gs_device_filter {
 	union {
 		struct gs_device_filter_bxcan bxcan;
 	};
+} __packed __aligned(4);
+
+enum gs_device_tdc_mode {
+	GS_CAN_TDC_MODE_OFF = BIT(0),
+	GS_CAN_TDC_MODE_AUTO = BIT(1),
+	GS_CAN_TDC_MODE_MANUAL = BIT(2),
+};
+
+struct gs_device_tdc_const {
+	u32 tdcv_min;
+	u32 tdcv_max;
+	u32 tdco_min;
+	u32 tdco_max;
+	u32 tdcf_min;
+	u32 tdcf_max;
+	u32 mode;
+} __packed __aligned(4);
+
+struct gs_device_tdc {
+	u32 tdcv;
+	u32 tdco;
+	u32 tdcf;
+	enum gs_device_tdc_mode mode;
 } __packed __aligned(4);
 
 struct gs_device_bus_off_recovery {

--- a/include/usbd_gs_can.h
+++ b/include/usbd_gs_can.h
@@ -89,6 +89,7 @@ typedef struct {
 
 			// Device <-> Host
 			struct gs_device_termination_state term_state;
+			struct gs_device_tdc tdc;
 		}; );
 		uint8_t __aligned(4) buf[sizeof(struct ep0_data)];
 	} ep0;

--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -302,28 +302,28 @@ bool can_send(can_data_t *channel, struct gs_host_frame *frame)
 	}
 }
 
-bool can_drv_bus_error_pending(const uint32_t reg_esr)
+bool can_drv_bus_error_pending(const struct can_channel *channel)
 {
+	const uint32_t reg_esr = channel->reg_status.esr;
 	const uint8_t lec = FIELD_GET(CAN_ESR_LEC, reg_esr);
 
 	return can_is_lec_error(lec);
 }
 
-uint32_t can_drv_read_reg_status(const struct can_channel *channel)
+void can_drv_read_reg_status(struct can_channel *channel)
 {
-	const uint32_t reg_esr = channel->instance->ESR;
+	channel->reg_status.esr = channel->instance->ESR;
 
-	if (can_drv_bus_error_pending(reg_esr)) {
+	if (can_drv_bus_error_pending(channel)) {
 		/* mark as handled by software */
 		channel->instance->ESR |= FIELD_PREP(CAN_ESR_LEC, CAN_LEC_SOFTWARE);
 	}
-
-	return reg_esr;
 }
 
-bool can_drv_handle_bus_error(const struct can_channel __maybe_unused *channel, struct gs_host_frame *frame,
-							  const uint32_t reg_esr)
+bool can_drv_handle_bus_error(const struct can_channel *channel, struct gs_host_frame *frame)
 {
+	const uint32_t reg_esr = channel->reg_status.esr;
+
 	const uint8_t tx_err = FIELD_GET(CAN_ESR_TEC, reg_esr);
 	const uint8_t rx_err = FIELD_GET(CAN_ESR_REC, reg_esr);
 
@@ -341,8 +341,10 @@ bool can_drv_handle_bus_error(const struct can_channel __maybe_unused *channel, 
 	return true;
 }
 
-enum gs_can_state can_drv_get_state(const uint32_t reg_esr)
+enum gs_can_state can_drv_get_state(const struct can_channel *channel)
 {
+	const uint32_t reg_esr = channel->reg_status.esr;
+
 	if (!(reg_esr & (CAN_ESR_BOFF | CAN_ESR_EPVF | CAN_ESR_EWGF))) {
 		return GS_CAN_STATE_ERROR_ACTIVE;
 	}
@@ -358,25 +360,24 @@ enum gs_can_state can_drv_get_state(const uint32_t reg_esr)
 	return GS_CAN_STATE_ERROR_WARNING;
 }
 
-void can_drv_get_device_state(const struct can_channel __maybe_unused *channel, struct gs_device_state *state,
-							  const uint32_t reg_esr)
+void can_drv_get_device_state(const struct can_channel *channel, struct gs_device_state *state)
 {
-	state->state = can_drv_get_state(reg_esr);
+	const uint32_t reg_esr = channel->reg_status.esr;
+
+	state->state = can_drv_get_state(channel);
 	state->rxerr = FIELD_GET(CAN_ESR_REC, reg_esr);
 	state->txerr = FIELD_GET(CAN_ESR_TEC, reg_esr);
 }
 
-void can_drv_handle_state_change(const struct can_channel __maybe_unused *channel, struct gs_host_frame *frame,
-								 const uint32_t reg_esr)
+void can_drv_handle_state_change(const struct can_channel *channel, struct gs_host_frame *frame)
 {
-	enum gs_can_state tx_state, rx_state;
-	uint8_t tx_err, rx_err;
+	const uint32_t reg_esr = channel->reg_status.esr;
 
-	tx_err = FIELD_GET(CAN_ESR_TEC, reg_esr);
-	rx_err = FIELD_GET(CAN_ESR_REC, reg_esr);
+	const uint8_t tx_err = FIELD_GET(CAN_ESR_TEC, reg_esr);
+	const uint8_t rx_err = FIELD_GET(CAN_ESR_REC, reg_esr);
 
-	tx_state = can_err_to_state(tx_err);
-	rx_state = can_err_to_state(rx_err);
+	const enum gs_can_state tx_state = can_err_to_state(tx_err);
+	const enum gs_can_state rx_state = can_err_to_state(rx_err);
 
 	if (tx_state >= rx_state) {
 		frame->classic_can->data[1] |= gs_can_tx_state_to_frame(tx_state);

--- a/src/can/bxcan.c
+++ b/src/can/bxcan.c
@@ -103,14 +103,6 @@ void can_init(can_data_t *channel, const struct board_channel_config *channel_co
 	filter->fa1r = 0x1;     // Enable filter bank 0
 }
 
-void can_set_bittiming(can_data_t *channel, const struct gs_device_bittiming *timing)
-{
-	channel->btr = FIELD_PREP(CAN_BTR_SJW, timing->sjw - 1) |
-				   FIELD_PREP(CAN_BTR_TS2, timing->phase_seg2 - 1) |
-				   FIELD_PREP(CAN_BTR_TS1, timing->prop_seg + timing->phase_seg1 - 1) |
-				   FIELD_PREP(CAN_BTR_BRP, timing->brp - 1);
-}
-
 #ifdef CONFIG_CAN_FILTER
 void can_set_filter(can_data_t *channel, const struct gs_device_filter *filter)
 {
@@ -160,7 +152,10 @@ void can_drv_enable(struct can_channel *channel)
 		mcr |= CAN_MCR_NART;
 	}
 
-	uint32_t btr = channel->btr;
+	uint32_t btr = FIELD_PREP(CAN_BTR_SJW, channel->bittiming.sjw - 1) |
+				   FIELD_PREP(CAN_BTR_TS2, channel->bittiming.phase_seg2 - 1) |
+				   FIELD_PREP(CAN_BTR_TS1, channel->bittiming.prop_seg + channel->bittiming.phase_seg1 - 1) |
+				   FIELD_PREP(CAN_BTR_BRP, channel->bittiming.brp - 1);
 
 	if (feature & GS_CAN_FEATURE_LISTEN_ONLY) {
 		btr |= CAN_MODE_SILENT;

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -77,6 +77,12 @@ bool can_check_feature_ok(const can_data_t *channel,
 	if (!IS_ENABLED(CONFIG_CANFD))
 		return true;
 
+	/* TDC requires TDC parameters to be set */
+	if (feature & GS_CAN_FEATURE_TDC &&
+		!(channel->flags & CAN_CHANNEL_FLAG_TDC_SET)) {
+		return false;
+	}
+
 	return true;
 }
 
@@ -86,6 +92,48 @@ void can_set_data_bittiming(struct can_channel *channel, const struct gs_device_
 	channel->flags |= CAN_CHANNEL_FLAG_DATA_BITTIMING_SET;
 
 	channel->data_bittiming = *bt;
+}
+
+bool can_check_tdc_ok(const struct gs_device_tdc_const *tdc_const,
+					  const struct gs_device_tdc *tdc)
+{
+	if (tdc->tdcv < tdc_const->tdcv_min || tdc->tdcv > tdc_const->tdcv_max ||
+		tdc->tdco < tdc_const->tdco_min || tdc->tdco > tdc_const->tdco_max ||
+		tdc->tdcf < tdc_const->tdcf_min || tdc->tdcf > tdc_const->tdcf_max)
+		return false;
+
+	const uint32_t mode = tdc->mode & (GS_CAN_TDC_MODE_OFF | GS_CAN_TDC_MODE_AUTO | GS_CAN_TDC_MODE_MANUAL);
+
+	/* one of OFF, AUTO or MANUAL must be active */
+	if (!mode || mode & (mode - 1))
+		return false;
+
+	if (tdc->tdcv) {
+		/* TDCV is incompatible with AUTO */
+		if (mode & GS_CAN_TDC_MODE_AUTO) {
+			return false;
+		}
+	} else {
+		/* MANUAL requires TDCV */
+		if (mode & GS_CAN_TDC_MODE_MANUAL) {
+			return false;
+		}
+	}
+
+	/* TDCO is mandatory for AUTO or MANUAL */
+	if ((mode & GS_CAN_TDC_MODE_AUTO || mode & GS_CAN_TDC_MODE_MANUAL) &&
+		!tdc->tdco) {
+		return false;
+	}
+
+	return true;
+}
+
+void can_set_tdc(struct can_channel *channel, const struct gs_device_tdc *tdc)
+{
+	channel->flags |= CAN_CHANNEL_FLAG_TDC_SET;
+
+	channel->tdc = *tdc;
 }
 #endif
 

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -63,6 +63,11 @@ bool can_check_bittiming_ok(const struct can_bittiming_const *btc,
 	return true;
 }
 
+void can_set_bittiming(struct can_channel *channel, const struct gs_device_bittiming *bt)
+{
+	channel->bittiming = *bt;
+}
+
 #ifdef CONFIG_CAN_FILTER
 bool can_check_filter_ok(const struct gs_device_filter *filter)
 {

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -89,10 +89,11 @@ bool can_is_enabled(const struct can_channel *channel)
 
 void can_enable(struct can_channel *channel, const uint32_t feature)
 {
-	channel->feature = feature;
-
 	led_set_mode(&channel->leds, LED_MODE_NORMAL);
+
+	channel->feature = feature;
 	channel->state = GS_CAN_STATE_ERROR_ACTIVE;
+
 	board_phy_power_set(channel, true);
 	can_drv_enable(channel);
 }
@@ -101,11 +102,14 @@ void can_disable(USBD_GS_CAN_HandleTypeDef *hcan, struct can_channel *channel)
 {
 	can_drv_disable(channel);
 	board_phy_power_set(channel, false);
+
 	usbd_gs_can_purge_from_host_list_by_channel(hcan, channel);
 	usbd_gs_can_purge_to_host_list_by_channel(hcan, channel);
 
 	channel->bus_off_restart = CAN_CHANNEL_BUS_OFF_RESTART_DISABLED;
 	channel->state = GS_CAN_STATE_STOPPED;
+	channel->feature = 0;
+
 	led_set_mode(&channel->leds, LED_MODE_OFF);
 }
 

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -70,6 +70,15 @@ void can_set_bittiming(struct can_channel *channel, const struct gs_device_bitti
 	channel->bittiming = *bt;
 }
 
+bool can_check_feature_ok(const can_data_t *channel,
+						  const uint32_t feature)
+{
+	if (!IS_ENABLED(CONFIG_CANFD))
+		return true;
+
+	return true;
+}
+
 #ifdef CONFIG_CANFD
 void can_set_data_bittiming(struct can_channel *channel, const struct gs_device_bittiming *bt)
 {

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -135,6 +135,19 @@ void can_set_tdc(struct can_channel *channel, const struct gs_device_tdc *tdc)
 
 	channel->tdc = *tdc;
 }
+
+void can_get_device_tdc(const struct can_channel *channel, struct gs_device_tdc *tdc)
+{
+	if (tdc->mode == GS_CAN_TDC_MODE_OFF) {
+		*tdc = (struct gs_device_tdc){
+			.mode = GS_CAN_TDC_MODE_OFF
+		};
+	} else {
+		*tdc = channel->tdc;
+		can_drv_get_device_tdc(channel, tdc);
+	}
+}
+
 #endif
 
 #ifdef CONFIG_CAN_FILTER

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -68,6 +68,13 @@ void can_set_bittiming(struct can_channel *channel, const struct gs_device_bitti
 	channel->bittiming = *bt;
 }
 
+#ifdef CONFIG_CANFD
+void can_set_data_bittiming(struct can_channel *channel, const struct gs_device_bittiming *bt)
+{
+	channel->data_bittiming = *bt;
+}
+#endif
+
 #ifdef CONFIG_CAN_FILTER
 bool can_check_filter_ok(const struct gs_device_filter *filter)
 {

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -162,9 +162,7 @@ void CAN_ReceiveFrame(USBD_GS_CAN_HandleTypeDef *hcan, can_data_t *channel)
 
 void can_get_device_state(const struct can_channel *channel, struct gs_device_state *state)
 {
-	const uint32_t reg_status = can_drv_read_reg_status(channel);
-
-	can_drv_get_device_state(channel, state, reg_status);
+	can_drv_get_device_state(channel, state);
 }
 
 static void can_prepare_error_frame(const struct can_channel *channel,
@@ -248,8 +246,7 @@ void can_lec_error_to_frame(struct gs_host_frame *frame, const uint8_t lec)
 	}
 }
 
-static void can_handle_bus_error(USBD_GS_CAN_HandleTypeDef *hcan, const struct can_channel *channel,
-								 const uint32_t reg_status)
+static void can_handle_bus_error(USBD_GS_CAN_HandleTypeDef *hcan, const struct can_channel *channel)
 {
 	struct gs_host_frame_object *frame_object = gs_host_frame_object_get_locked(hcan);
 	if (!frame_object)
@@ -258,7 +255,7 @@ static void can_handle_bus_error(USBD_GS_CAN_HandleTypeDef *hcan, const struct c
 	struct gs_host_frame *frame = &frame_object->frame;
 
 	can_prepare_error_frame(channel, frame);
-	bool handled = can_drv_handle_bus_error(channel, frame, reg_status);
+	bool handled = can_drv_handle_bus_error(channel, frame);
 	if (handled) {
 		list_add_tail_locked(&frame_object->list, &hcan->list_to_host);
 	} else {
@@ -266,13 +263,13 @@ static void can_handle_bus_error(USBD_GS_CAN_HandleTypeDef *hcan, const struct c
 	}
 }
 
-static bool can_bus_error_pending(const struct can_channel *channel, const uint32_t reg_status)
+static bool can_bus_error_pending(const struct can_channel *channel)
 {
 	if (!(channel->feature & GS_CAN_FEATURE_BERR_REPORTING)) {
 		return false;
 	}
 
-	return can_drv_bus_error_pending(reg_status);
+	return can_drv_bus_error_pending(channel);
 }
 
 bool can_check_bus_off_recovery_ok(const struct can_channel *channel)
@@ -289,8 +286,7 @@ void can_schedule_bus_off_recovery(struct can_channel *channel, const uint32_t d
 		channel->bus_off_restart++;
 }
 
-static void can_handle_state_change(USBD_GS_CAN_HandleTypeDef *hcan, struct can_channel *channel,
-									const uint32_t reg_status)
+static void can_handle_state_change(USBD_GS_CAN_HandleTypeDef *hcan, struct can_channel *channel)
 {
 	struct gs_host_frame_object *frame_object = gs_host_frame_object_get_locked(hcan);
 	if (!frame_object)
@@ -307,19 +303,19 @@ static void can_handle_state_change(USBD_GS_CAN_HandleTypeDef *hcan, struct can_
 			can_schedule_bus_off_recovery(channel, CAN_BUS_OFF_RESTART_DELAY_MS);
 	} else {
 		frame->can_id |= CAN_ERR_CRTL | CAN_ERR_CNT;
-		can_drv_handle_state_change(channel, frame, reg_status);
-		can_drv_handle_bus_error(channel, frame, reg_status);
+		can_drv_handle_state_change(channel, frame);
+		can_drv_handle_bus_error(channel, frame);
 	}
 
 	list_add_tail_locked(&frame_object->list, &hcan->list_to_host);
 }
 
-static bool can_state_change_pending(struct can_channel *channel, const uint32_t reg_status)
+static bool can_state_change_pending(struct can_channel *channel)
 {
 	if (!can_is_enabled(channel))
 		return false;
 
-	const enum gs_can_state new_state = can_drv_get_state(reg_status);
+	const enum gs_can_state new_state = can_drv_get_state(channel);
 	if (channel->state == new_state)
 		return false;
 
@@ -366,12 +362,12 @@ void CAN_HandleError(USBD_GS_CAN_HandleTypeDef *hcan, can_data_t *channel)
 		return;
 	}
 
-	const uint32_t reg_status = can_drv_read_reg_status(channel);
+	can_drv_read_reg_status(channel);
 
-	if (can_state_change_pending(channel, reg_status)) {
-		can_handle_state_change(hcan, channel, reg_status);
-	} else if (can_bus_error_pending(channel, reg_status)) {
-		can_handle_bus_error(hcan, channel, reg_status);
+	if (can_state_change_pending(channel)) {
+		can_handle_state_change(hcan, channel);
+	} else if (can_bus_error_pending(channel)) {
+		can_handle_bus_error(hcan, channel);
 	} else if (can_bus_off_recovery_pending(channel)) {
 		can_handle_bus_off_recovery(hcan, channel);
 	}

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -40,6 +40,7 @@
 
 #ifndef CONFIG_CANFD
 const struct gs_device_bt_const_extended CAN_btconst_ext;
+const struct gs_device_tdc_const CAN_tdc_const;
 #endif
 
 #ifndef CONFIG_CAN_FILTER

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -148,6 +148,50 @@ void can_get_device_tdc(const struct can_channel *channel, struct gs_device_tdc 
 	}
 }
 
+static void can_clear_tdc(can_data_t *channel)
+{
+	channel->tdc = (struct gs_device_tdc){ 0 };
+}
+
+static void can_calc_tdco(can_data_t *channel)
+{
+	/* host configured a TDC mode, skip TDCO calculation */
+	if (channel->feature & GS_CAN_FEATURE_TDC) {
+		return;
+	}
+
+	struct gs_device_tdc *tdc = &channel->tdc;
+	tdc->mode = GS_CAN_TDC_MODE_OFF;
+
+	/* TDC is only needed for CAN_FD */
+	if (!(channel->feature & GS_CAN_FEATURE_FD)) {
+		return;
+	}
+
+	/* host has not configured a TDC */
+	const struct gs_device_bittiming *dbt = &channel->data_bittiming;
+	const struct gs_device_tdc_const *tdc_const = &CAN_tdc_const;
+
+	if (!(dbt->brp == 1 || dbt->brp == 2)) {
+		return;
+	}
+
+	const uint32_t sample_point_in_tc = (1 + dbt->prop_seg + dbt->phase_seg1) * dbt->brp;
+	if (sample_point_in_tc < tdc_const->tdco_min) {
+		return;
+	}
+
+	tdc->tdco = min(sample_point_in_tc, tdc_const->tdco_max);
+	tdc->mode = GS_CAN_TDC_MODE_AUTO;
+}
+#else
+static inline void can_clear_tdc(can_data_t __maybe_unused *channel)
+{
+}
+
+static inline void can_calc_tdco(can_data_t __maybe_unused *channel)
+{
+}
 #endif
 
 #ifdef CONFIG_CAN_FILTER
@@ -168,6 +212,7 @@ void can_enable(struct can_channel *channel, const uint32_t feature)
 
 	channel->feature = feature;
 	channel->state = GS_CAN_STATE_ERROR_ACTIVE;
+	can_calc_tdco(channel);
 
 	board_phy_power_set(channel, true);
 	can_drv_enable(channel);
@@ -181,6 +226,7 @@ void can_disable(USBD_GS_CAN_HandleTypeDef *hcan, struct can_channel *channel)
 	usbd_gs_can_purge_from_host_list_by_channel(hcan, channel);
 	usbd_gs_can_purge_to_host_list_by_channel(hcan, channel);
 
+	can_clear_tdc(channel);
 	channel->bus_off_restart = CAN_CHANNEL_BUS_OFF_RESTART_DISABLED;
 	channel->state = GS_CAN_STATE_STOPPED;
 	channel->flags = 0;

--- a/src/can_common.c
+++ b/src/can_common.c
@@ -65,12 +65,16 @@ bool can_check_bittiming_ok(const struct can_bittiming_const *btc,
 
 void can_set_bittiming(struct can_channel *channel, const struct gs_device_bittiming *bt)
 {
+	channel->flags |= CAN_CHANNEL_FLAG_BITTIMING_SET;
+
 	channel->bittiming = *bt;
 }
 
 #ifdef CONFIG_CANFD
 void can_set_data_bittiming(struct can_channel *channel, const struct gs_device_bittiming *bt)
 {
+	channel->flags |= CAN_CHANNEL_FLAG_DATA_BITTIMING_SET;
+
 	channel->data_bittiming = *bt;
 }
 #endif
@@ -108,6 +112,7 @@ void can_disable(USBD_GS_CAN_HandleTypeDef *hcan, struct can_channel *channel)
 
 	channel->bus_off_restart = CAN_CHANNEL_BUS_OFF_RESTART_DISABLED;
 	channel->state = GS_CAN_STATE_STOPPED;
+	channel->flags = 0;
 	channel->feature = 0;
 
 	led_set_mode(&channel->leds, LED_MODE_OFF);

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -380,6 +380,7 @@ static uint8_t USBD_GS_CAN_Config_Request(USBD_HandleTypeDef *pdev, USBD_SetupRe
 		switch (req->bRequest) {
 			case GS_USB_BREQ_DATA_BITTIMING:
 			case GS_USB_BREQ_BT_CONST_EXT:
+			case GS_USB_BREQ_GET_TDC_CONST:
 				goto out_fail;
 		}
 	}
@@ -453,6 +454,10 @@ static uint8_t USBD_GS_CAN_Config_Request(USBD_HandleTypeDef *pdev, USBD_SetupRe
 			src = &CAN_filter_info;
 			len = sizeof(CAN_filter_info);
 			break;
+		case GS_USB_BREQ_GET_TDC_CONST:
+			src = &CAN_tdc_const;
+			len = sizeof(CAN_tdc_const);
+			break;
 		case GS_USB_BREQ_BUS_OFF_RECOVERY:
 			len = 0;
 			break;
@@ -489,6 +494,7 @@ static uint8_t USBD_GS_CAN_Config_Request(USBD_HandleTypeDef *pdev, USBD_SetupRe
 		case GS_USB_BREQ_GET_TERMINATION:
 		case GS_USB_BREQ_GET_STATE:
 		case GS_USB_BREQ_GET_FILTER:
+		case GS_USB_BREQ_GET_TDC_CONST:
 			USBD_CtlSendData(pdev, (uint8_t *)src, len);
 			break;
 		default:

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -382,6 +382,7 @@ static uint8_t USBD_GS_CAN_Config_Request(USBD_HandleTypeDef *pdev, USBD_SetupRe
 			case GS_USB_BREQ_BT_CONST_EXT:
 			case GS_USB_BREQ_GET_TDC_CONST:
 			case GS_USB_BREQ_SET_TDC:
+			case GS_USB_BREQ_GET_TDC:
 				goto out_fail;
 		}
 	}
@@ -462,6 +463,11 @@ static uint8_t USBD_GS_CAN_Config_Request(USBD_HandleTypeDef *pdev, USBD_SetupRe
 		case GS_USB_BREQ_SET_TDC:
 			len = sizeof(ep0->tdc);
 			break;
+		case GS_USB_BREQ_GET_TDC:
+			can_get_device_tdc(channel, &ep0->tdc);
+			src = &ep0->tdc;
+			len = sizeof(ep0->tdc);
+			break;
 		case GS_USB_BREQ_BUS_OFF_RECOVERY:
 			len = 0;
 			break;
@@ -500,6 +506,7 @@ static uint8_t USBD_GS_CAN_Config_Request(USBD_HandleTypeDef *pdev, USBD_SetupRe
 		case GS_USB_BREQ_GET_STATE:
 		case GS_USB_BREQ_GET_FILTER:
 		case GS_USB_BREQ_GET_TDC_CONST:
+		case GS_USB_BREQ_GET_TDC:
 			USBD_CtlSendData(pdev, (uint8_t *)src, len);
 			break;
 		default:

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -615,6 +615,9 @@ static uint8_t USBD_GS_CAN_EP0_RxReady(USBD_HandleTypeDef *pdev) {
 			if (mode->mode == GS_CAN_MODE_RESET) {
 				can_disable(hcan, channel);
 			} else if (mode->mode == GS_CAN_MODE_START) {
+				if (!can_check_feature_ok(channel, mode->feature))
+					goto out_fail;
+
 				can_enable(channel, mode->feature);
 			}
 			break;

--- a/src/usbd_gs_can.c
+++ b/src/usbd_gs_can.c
@@ -381,6 +381,7 @@ static uint8_t USBD_GS_CAN_Config_Request(USBD_HandleTypeDef *pdev, USBD_SetupRe
 			case GS_USB_BREQ_DATA_BITTIMING:
 			case GS_USB_BREQ_BT_CONST_EXT:
 			case GS_USB_BREQ_GET_TDC_CONST:
+			case GS_USB_BREQ_SET_TDC:
 				goto out_fail;
 		}
 	}
@@ -458,6 +459,9 @@ static uint8_t USBD_GS_CAN_Config_Request(USBD_HandleTypeDef *pdev, USBD_SetupRe
 			src = &CAN_tdc_const;
 			len = sizeof(CAN_tdc_const);
 			break;
+		case GS_USB_BREQ_SET_TDC:
+			len = sizeof(ep0->tdc);
+			break;
 		case GS_USB_BREQ_BUS_OFF_RECOVERY:
 			len = 0;
 			break;
@@ -477,6 +481,7 @@ static uint8_t USBD_GS_CAN_Config_Request(USBD_HandleTypeDef *pdev, USBD_SetupRe
 		case GS_USB_BREQ_DATA_BITTIMING:
 		case GS_USB_BREQ_SET_TERMINATION:
 		case GS_USB_BREQ_SET_FILTER:
+		case GS_USB_BREQ_SET_TDC:
 		case GS_USB_BREQ_BUS_OFF_RECOVERY:
 			if (req->wLength > sizeof(*ep0)) {
 				goto out_fail;
@@ -575,6 +580,7 @@ static uint8_t USBD_GS_CAN_EP0_RxReady(USBD_HandleTypeDef *pdev) {
 	if (!IS_ENABLED(CONFIG_CANFD)) {
 		switch (req->bRequest) {
 			case GS_USB_BREQ_DATA_BITTIMING:
+			case GS_USB_BREQ_SET_TDC:
 				goto out_fail;
 		}
 	}
@@ -661,6 +667,15 @@ static uint8_t USBD_GS_CAN_EP0_RxReady(USBD_HandleTypeDef *pdev) {
 				goto out_fail;
 
 			can_set_filter(channel, filter);
+			break;
+		}
+		case GS_USB_BREQ_SET_TDC: {
+			const struct gs_device_tdc *tdc = &ep0->tdc;
+
+			if (can_is_enabled(channel) || !can_check_tdc_ok(&CAN_tdc_const, tdc))
+				goto out_fail;
+
+			can_set_tdc(channel, tdc);
 			break;
 		}
 		case GS_USB_BREQ_BUS_OFF_RECOVERY:


### PR DESCRIPTION
The device sets `GS_CAN_FEATURE_TDC` if it supports TDC configuration.

Use `GS_USB_BREQ_GET_TDC_CONST` to get TDC information (`struct gs_device_tdc_const`) from the device.

`struct gs_device_tdc_const::tdcv_min`
Transmitter Delay Compensation Value minimum value.

`struct gs_device_tdc_const::tdcv_max`
Transmitter Delay Compensation Value maximum value.

`struct gs_device_tdc_const::tdco_min`
Transmitter Delay Compensation Offset minimum value.

`struct gs_device_tdc_const::tdco_max`
Transmitter Delay Compensation Offset maximum value.

`struct gs_device_tdc_const::tdcf_min`
Transmitter Delay Compensation Filter window minimum value.

`struct gs_device_tdc_const::tdcf_max`
Transmitter Delay Compensation Filter window maximum value.

`struct gs_device_tdc_const::mode` specifies the supported TDC modes:

- `GS_CAN_TDC_MODE_OFF`
  TDC is explicitly disabled.

- `GS_CAN_TDC_MODE_AUTO`
  The user must provide the `tdco` argument. The `tdcv` will be automatically calculated by the device.

- `GS_CAN_TDC_MODE_MANUAL`
  The user must provide both the `tdco` and `tdcv` arguments.

Use `GS_USB_BREQ_SET_TDC` with `truct gs_device_tdc` to configure TDC in the device.
Then set `GS_CAN_FEATURE_TDC` in `struct gs_device_mode::feature` during open to activate it.

For backwards compatibility,
for host software not supporting TDC the device will automatically decide whether TDC should be turned on,
in which case it will calculate a default `tdco` and use the `tdcv` as measured by the device.

Use `GS_USB_BREQ_GET_TDC` to query current active TDC parameters.
Note: `struct gs_device_tdc::tdcv` is only valid after at least 1 CAN-FD frame has been send.

Closes: https://github.com/candle-usb/candleLight_fw/issues/173